### PR TITLE
feat: Always fetch the latest Tailscale release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,38 @@ to provide a persistent service and runs using Tailscale's usermode networking f
 2. Run the `install.sh` script to install `tailscale` and the startup script on your UDM.
    
    ```sh
-   curl -sSL https://raw.github.com/SierraSoftworks/tailscale-udm/master/install.sh | TAILSCALE_VERSION=1.18.2 sh
+   # Install the latest version of Tailscale
+   curl -sSLq https://raw.github.com/SierraSoftworks/tailscale-udm/master/install.sh | sh
+
+   # Install a specific version of Tailscale
+   curl -sSLq https://raw.github.com/SierraSoftworks/tailscale-udm/master/install.sh | TAILSCALE_VERSION=1.20.0 sh
+
+   # Install Tailscale and start it with some custom flags
+   curl -sSLq https://raw.github.com/SierraSoftworks/tailscale-udm/master/install.sh | TAILSCALE_FLAGS="--authkey XXXXXXX" sh
    ```
 3. Follow the on-screen steps to configure `tailscale` and connect it to your network.
 4. Confirm that `tailscale` is working by running `/mnt/data/tailscale/tailscale status`
 
 ### Upgrade Tailscale
-Upgrading can be done by running the upgrade script below (replace `1.12.3` with the version you want to upgrade to).
+Upgrading can be done by running the upgrade script below.
 
 ```sh
-/mnt/data/tailscale/upgrade.sh 1.12.3
+# Upgrade to the latest version of Tailscale
+curl -sSLq https://raw.github.com/SierraSoftworks/tailscale-udm/master/upgrade.sh | sh
+
+# Upgrade to a specific version of Tailscale using your local script
+/mnt/data/tailscale/upgrade.sh 1.20.0
 ```
 
 ### Remove Tailscale
 To remove Tailscale, you can run the following command, or run the steps below manually.
    
 ```sh
-curl -sSL https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/uninstall.sh | sh
+# Remove Tailscale from your UDM using the automated script
+curl -sSLq https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/uninstall.sh | sh
 ```
 
+#### Manual Steps
 1. Kill the `tailscaled` daemon.
    
    ```sh

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-VERSION="${TAILSCALE_VERSION:-1.18.2}"
+VERSION="${TAILSCALE_VERSION:-$1}"
+VERSION="${VERSION:-$(curl -sSLq 'https://api.github.com/repos/tailscale/tailscale/releases' | jq -r '.[0].tag_name | capture("v(?<version>.+)").version')}"
 WORKDIR="$(mktemp -d || exit 1)"
 trap 'rm -rf ${WORKDIR}' EXIT
 TAILSCALE_TGZ="${WORKDIR}/tailscale.tgz"
@@ -13,15 +14,15 @@ mkdir -p /mnt/data/tailscale
 cp -R "${WORKDIR}/tailscale_${VERSION}_arm64"/* /mnt/data/tailscale/
 
 echo "Installing Tailscale upgrade script in /mnt/data/tailscale/upgrade.sh"
-curl -o /mnt/data/tailscale/upgrade.sh -sSL https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/upgrade.sh
+curl -o /mnt/data/tailscale/upgrade.sh -sSLq https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/upgrade.sh
 chmod +x /mnt/data/tailscale/upgrade.sh
 
 echo "Installing boot script for Tailscale"
-curl -o /mnt/data/on_boot.d/10-tailscaled.sh -sSL https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/on_boot.d/10-tailscaled.sh
+curl -o /mnt/data/on_boot.d/10-tailscaled.sh -sSLq https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/on_boot.d/10-tailscaled.sh
 chmod +x /mnt/data/on_boot.d/10-tailscaled.sh
 
 echo "Installing tailscale env script"
-curl -o /mnt/data/tailscale/tailscale-env -sSL https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/tailscale-env
+curl -o /mnt/data/tailscale/tailscale-env -sSLq https://raw.githubusercontent.com/SierraSoftworks/tailscale-udm/main/tailscale-env
 
 echo "Starting tailscaled service"
 /mnt/data/on_boot.d/10-tailscaled.sh

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ ! -f /mnt/data/tailscale/tailscale ]]; then
+if [ ! -f /mnt/data/tailscale/tailscale ]; then
   echo "Tailscale is not installed on this device."
   exit 1
 fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [[ ! -f /mnt/data/tailscale/tailscale ]]; then
+  echo "Tailscale is not installed on this device."
+  exit 1
+fi
+
 echo "Shutting down tailscaled"
 /mnt/data/tailscale/tailscale down
 killall tailscaled

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 set -e
 
-VERSION="${1:-1.18.2}"
+VERSION="${TAILSCALE_VERSION:-$1}"
+VERSION="${VERSION:-$(curl -sSLq 'https://api.github.com/repos/tailscale/tailscale/releases' | jq -r '.[0].tag_name | capture("v(?<version>.+)").version')}"
 WORKDIR="$(mktemp -d || exit 1)"
 trap 'rm -rf ${WORKDIR}' EXIT
 TAILSCALE_TGZ="${WORKDIR}/tailscale.tgz"
 
 echo "Installing Tailscale in /mnt/data/tailscale"
-curl -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
+curl -sSLq -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
 tar xzf "${TAILSCALE_TGZ}" -C "${WORKDIR}"
 mkdir -p /mnt/data/tailscale
 


### PR DESCRIPTION
This PR expands the install and upgrade scripts to use `curl` and `jq` to resolve the latest Tailscale release (from https://github.com/tailscale/tailscale/releases) whenever they are run without arguments or the `TAILSCALE_VERSION` environment variable set.