### PR TITLE
fix: Ensure that we handle HTTP errors when attempting to download packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ WORKDIR="$(mktemp -d || exit 1)"
 trap 'rm -rf ${WORKDIR}' EXIT
 
 # Download the Tailscale-UDM package
-curl -sSL -o "${WORKDIR}/tailscale.tgz" "https://github.com/SierraSoftworks/tailscale-udm/releases/download/${VERSION}/tailscale-udm.tgz"
+curl -sSLf -o "${WORKDIR}/tailscale.tgz" "https://github.com/SierraSoftworks/tailscale-udm/releases/download/${VERSION}/tailscale-udm.tgz"
 
 # Extract the package
 tar xzf "${WORKDIR}/tailscale.tgz" -C "/mnt/data/"

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -60,7 +60,7 @@ tailscale_install() {
   TAILSCALE_TGZ="${WORKDIR}/tailscale.tgz"
 
   echo "Installing Tailscale v${VERSION} in ${TAILSCALE_ROOT}..."
-  curl -sSL -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
+  curl -sSLf -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
   tar xzf "${TAILSCALE_TGZ}" -C "${WORKDIR}"
   mkdir -p "${TAILSCALE_ROOT}"
   cp -R "${WORKDIR}/tailscale_${VERSION}_arm64"/* "${TAILSCALE_ROOT}"

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -54,7 +54,7 @@ tailscale_stop() {
 }
 
 tailscale_install() {
-  VERSION="${1:-$(curl -sSLq 'https://api.github.com/repos/tailscale/tailscale/releases' | jq -r '.[0].tag_name | capture("v(?<version>.+)").version')}"
+  VERSION="${1:-$(curl -sSLq 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.Tarballs.arm64 | capture("tailscale_(?<version>[^_]+)_").version')}"
   WORKDIR="$(mktemp -d || exit 1)"
   trap 'rm -rf ${WORKDIR}' EXIT
   TAILSCALE_TGZ="${WORKDIR}/tailscale.tgz"
@@ -77,7 +77,7 @@ tailscale_uninstall() {
 
 tailscale_has_update() {
   CURRENT_VERSION="$($TAILSCALE --version | head -n 1)"
-  TARGET_VERSION="${1:-$(curl -sSLq 'https://api.github.com/repos/tailscale/tailscale/releases' | jq -r '.[0].tag_name | capture("v(?<version>.+)").version')}"
+  TARGET_VERSION="${1:-$(curl -sSLq 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.Tarballs.arm64 | capture("tailscale_(?<version>[^_]+)_").version')}"
   if [ "${CURRENT_VERSION}" != "${TARGET_VERSION}" ]; then
     return 0
   else

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -60,7 +60,12 @@ tailscale_install() {
   TAILSCALE_TGZ="${WORKDIR}/tailscale.tgz"
 
   echo "Installing Tailscale v${VERSION} in ${TAILSCALE_ROOT}..."
-  curl -sSLf -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
+  curl -sSLf -o "${TAILSCALE_TGZ}" "https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz" || {
+    echo "Failed to download Tailscale v${VERSION} from https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
+    echo "Please make sure that you're using a valid version number and try again."
+    exit 1
+  }
+  
   tar xzf "${TAILSCALE_TGZ}" -C "${WORKDIR}"
   mkdir -p "${TAILSCALE_ROOT}"
   cp -R "${WORKDIR}/tailscale_${VERSION}_arm64"/* "${TAILSCALE_ROOT}"


### PR DESCRIPTION
This should address some of the issues we've seen that lead to #17 and #18 being created. It won't necessarily prevent these issues from occurring, but it should make it clearer when an issue does occur.