### PR TITLE
fix error on reinstall on uniOS 2.x

### DIFF
--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -43,7 +43,7 @@ _tailscale_install() {
     }
 
     echo "Installing Tailscale ${VERSION}..."
-    dpkg -i "${TAILSCALE_DEB}" || {
+    dpkg --force-confold -i "${TAILSCALE_DEB}" || {
         echo "Failed to install Tailscale v${VERSION} from ${TAILSCALE_DEB}"
         echo "Please make sure that you're using a valid version number and try again."
         exit 1


### PR DESCRIPTION
Proposed fix for #39

Currently, the install script modifies `/etc/default/tailscaled` to set userspace networking.

On reinstall (on uniOS 2.x), the modified config file causes `dpkg` to prompt, which fails with error `end of file on stdin at conffile prompt`

This PR updates the install process to call `dpkg` with `--force-confold` to instruct it to use the existing config.