### PR TITLE
feat: Store tailscaled state on /data for UniFi OS 2.x+

### DIFF
--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -48,9 +48,9 @@ _tailscale_install() {
     apt install -y tailscale="${VERSION}"
 
     echo "Configuring Tailscale to use userspace networking..."
-    sed -i 's/FLAGS=""/FLAGS="--tun userspace-networking"/' /etc/default/tailscaled || {
+    sed -i 's/FLAGS=""/FLAGS="--state /data/tailscale/tailscaled.state --tun userspace-networking"/' /etc/default/tailscaled || {
         echo "Failed to configure Tailscale to use userspace networking"
-        echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--tun userspace-networking\"."
+        echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state --tun userspace-networking\"."
         exit 1
     }
 


### PR DESCRIPTION
This PR addresses the issue of `tailscaled` state being erased upon firmware updates (described in #38) by telling `tailscaled` to store this state in the `/data/tailscale/tailscaled.state` file, which should not be removed during updates.

For users who are already running Tailscale on UniFi OS 2.x devices, you will want to manually migrate this state and update your defaults to match by running the following:

```sh
systemctl stop tailscaled
sed -i 's/FLAGS="--tun userspace-networking"/FLAGS="--state /data/tailscale/tailscaled.state --tun userspace-networking"/' /etc/default/tailscaled
mv /var/lib/tailscale/tailscaled.state /data/tailscale/tailscaled.state
systemctl start tailscaled

# This should continue to work without any issues
tailscale status
```