### PR TITLE
fix: Resolve an issue with sed updating the tailscaled flags for UniFi OS 2.x

### DIFF
--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -48,7 +48,7 @@ _tailscale_install() {
     apt install -y tailscale="${tailscale_version}"
 
     echo "Configuring Tailscale to use userspace networking..."
-    sed -i 's/FLAGS=""/FLAGS="--state /data/tailscale/tailscaled.state --tun userspace-networking"/' /etc/default/tailscaled || {
+    sed -i 's/FLAGS=""/FLAGS="--state \/data\/tailscale\/tailscaled.state --tun userspace-networking"/' /etc/default/tailscaled || {
         echo "Failed to configure Tailscale to use userspace networking"
         echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state --tun userspace-networking\"."
         exit 1


### PR DESCRIPTION
This PR fixes the issue reported in #45 which was caused by unescaped path segments in a `sed` replacement.