### PR TITLE
Add support for UniFi Cloudkey Gen2 Plus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,24 @@ trap 'rm -rf ${WORKDIR}' EXIT
 # Download the Tailscale-UDM package
 curl -sSLf --ipv4 -o "${WORKDIR}/tailscale.tgz" "$PACKAGE_URL"
 
-OS_VERSION="${FW_VERSION:-$(ubnt-device-info firmware_detail | grep -oE '^[0-9]+')}"
+if [ -x "$(which ubnt-device-info)" ]; then
+  OS_VERSION="${FW_VERSION:-$(ubnt-device-info firmware_detail | grep -oE '^[0-9]+')}"
+elif [ -f "/usr/lib/version" ]; then
+  # UCKP == Unifi CloudKey Gen2 Plus
+  # example /usr/lib/version file contents:
+  # UCKP.apq8053.v2.5.11.b2ebfc7.220801.1419
+  # UCKP.apq8053.v3.0.17.8102bbc.230210.1526
+  if [ "$(grep -c '^UCKP.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
+    OS_VERSION="$(sed -e 's/UCKP.*.v\(.\)\..*/\1/' /usr/lib/version)"
+  else
+    echo "Could not detect OS Version.  /usr/lib/version contains:"
+    cat /usr/lib/version
+    exit 1
+  fi
+else
+  echo "Could not detect OS Version.  No ubnt-device-info, no version file."
+  exit 1
+fi
 
 if [ "$OS_VERSION" = '1' ]; then
   export PACKAGE_ROOT="/mnt/data/tailscale"

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -2,7 +2,24 @@
 set -e
 
 PACKAGE_ROOT="${PACKAGE_ROOT:-"$(dirname -- "$(readlink -f -- "$0";)")"}"
-OS_VERSION="${FW_VERSION:-$(ubnt-device-info firmware_detail | grep -oE '^[0-9]+')}"
+if [ -x "$(which ubnt-device-info)" ]; then
+  OS_VERSION="${FW_VERSION:-$(ubnt-device-info firmware_detail | grep -oE '^[0-9]+')}"
+elif [ -f "/usr/lib/version" ]; then
+  # UCKP == Unifi CloudKey Gen2 Plus
+  # example /usr/lib/version file contents:
+  # UCKP.apq8053.v2.5.11.b2ebfc7.220801.1419
+  # UCKP.apq8053.v3.0.17.8102bbc.230210.1526
+  if [ "$(grep -c '^UCKP.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
+    OS_VERSION="$(sed -e 's/UCKP.*.v\(.\)\..*/\1/' /usr/lib/version)"
+  else
+    echo "Could not detect OS Version.  /usr/lib/version contains:"
+    cat /usr/lib/version
+    exit 1
+  fi
+else
+  echo "Could not detect OS Version.  No ubnt-device-info, no version file."
+  exit 1
+fi
 
 if [ "$OS_VERSION" = '1' ]; then
   # shellcheck source=package/unios_1.x.sh


### PR DESCRIPTION
This adds version detection for the UniFi CloudKey Gen2 Plus hardware which does not contain the ubnt-device-info binary.  That binary simply reads and parses /usr/lib/version from the filesystem, so I duplicated that behavior in shell for CloudKey Gen2 Plus device support.

I also included two example strings from a device before and after upgrade as comments, to help understand what the regex is doing.