### PR TITLE
Always fetch tailscale apt-key on install

### DIFF
--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -36,12 +36,14 @@ _tailscale_stop() {
 _tailscale_install() {
     tailscale_version="${1:-$(curl -sSLq --ipv4 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.Tarballs.arm64 | capture("tailscale_(?<version>[^_]+)_").version')}"
 
-    if [ ! -f "/etc/apt/sources.list.d/tailscale.list" ]; then
-        # shellcheck source=tests/os-release
-        . /etc/os-release
+    # shellcheck source=tests/os-release
+    . /etc/os-release
 
+    echo "Installing latest Tailscale package repository key..."
+    curl -fsSL --ipv4 "https://pkgs.tailscale.com/stable/${ID}/${VERSION_CODENAME}.gpg" | apt-key add -
+
+    if [ ! -f "/etc/apt/sources.list.d/tailscale.list" ]; then
         echo "Installing Tailscale package repository..."
-        curl -fsSL --ipv4 "https://pkgs.tailscale.com/stable/${ID}/${VERSION_CODENAME}.gpg" | apt-key add -
         curl -fsSL --ipv4 "https://pkgs.tailscale.com/stable/${ID}/${VERSION_CODENAME}.list" | tee /etc/apt/sources.list.d/tailscale.list
     fi
 


### PR DESCRIPTION
This changes the behavior of how the Tailscale apt repository is configured.  It always attempts to download the latest GPG key from Tailscale, even if the /etc/apt/sources.d/tailscale.list file exists.

This handles both the case where the key has been updated by Tailscale, and the case where the key was lost during a UniFi upgrade (but tailscale.list was retained), at the cost of an occasional extra https request to pkgs.tailscale.com.