### PR TITLE
feat: Add support for propagating TAILSCALED_FLAGS from tailscale-env for UniFi 2.x+ installs

### DIFF
--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -57,10 +57,10 @@ _tailscale_install() {
     # shellcheck source=package/tailscale-env
     . "$TAILSCALE_ROOT/tailscale-env"
 
-    echo "Configuring Tailscale to use userspace networking..."
+    echo "Configuring Tailscaled startup flags..."
     sed -i "s/FLAGS=""""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {
-        echo "Failed to configure Tailscale to use userspace networking"
-        echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state --tun userspace-networking\"."
+        echo "Failed to configure Tailscaled startup flags"
+        echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
         exit 1
     }
 

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -55,7 +55,7 @@ _tailscale_install() {
 
     # Load the tailscale-env file to discover the flags which are required to be set
     # shellcheck source=package/tailscale-env
-    . "$TAILSCALE_ROOT/tailscale-env"
+    . "${TAILSCALE_ROOT}/tailscale-env"
 
     echo "Configuring Tailscaled startup flags..."
     sed -i "s/FLAGS=""[^""]*""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -58,7 +58,7 @@ _tailscale_install() {
     . "$TAILSCALE_ROOT/tailscale-env"
 
     echo "Configuring Tailscaled startup flags..."
-    sed -i "s/FLAGS=""""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {
+    sed -i "s/FLAGS=""[^""]*""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {
         echo "Failed to configure Tailscaled startup flags"
         echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
         exit 1

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -53,8 +53,12 @@ _tailscale_install() {
     echo "Installing Tailscale ${tailscale_version}..."
     apt install -y tailscale="${tailscale_version}"
 
+    # Load the tailscale-env file to discover the flags which are required to be set
+    # shellcheck source=package/tailscale-env
+    . "$TAILSCALE_ROOT/tailscale-env"
+
     echo "Configuring Tailscale to use userspace networking..."
-    sed -i 's/FLAGS=""/FLAGS="--state \/data\/tailscale\/tailscaled.state --tun userspace-networking"/' /etc/default/tailscaled || {
+    sed -i "s/FLAGS=""""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {
         echo "Failed to configure Tailscale to use userspace networking"
         echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state --tun userspace-networking\"."
         exit 1

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -58,7 +58,7 @@ _tailscale_install() {
     . "${TAILSCALE_ROOT}/tailscale-env"
 
     echo "Configuring Tailscaled startup flags..."
-    sed -i "s/FLAGS=""[^""]*""/FLAGS=""--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}""/" /etc/default/tailscaled || {
+    sed -i "s/FLAGS=\"[^\"]*\"/FLAGS=\"--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}\"/" /etc/default/tailscaled || {
         echo "Failed to configure Tailscaled startup flags"
         echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
         exit 1

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -57,6 +57,13 @@ _tailscale_install() {
     # shellcheck source=package/tailscale-env
     . "${TAILSCALE_ROOT}/tailscale-env"
 
+    echo "Configuring Tailscale port..."
+    sed -i "s/PORT=\"[^\"]*\"/PORT=\"${PORT:-41641}\"/" /etc/default/tailscaled || {
+        echo "Failed to configure Tailscale port"
+        echo "Check that the file /etc/default/tailscaled exists and contains the line PORT=\"${PORT:-41641}\"."
+        exit 1
+    }
+
     echo "Configuring Tailscaled startup flags..."
     sed -i "s/FLAGS=\"[^\"]*\"/FLAGS=\"--state \/data\/tailscale\/tailscaled.state ${TAILSCALED_FLAGS}\"/" /etc/default/tailscaled || {
         echo "Failed to configure Tailscaled startup flags"

--- a/tests/install.2.x.test.sh
+++ b/tests/install.2.x.test.sh
@@ -54,6 +54,8 @@ esac
 EOF
 chmod +x "${WORKDIR}/systemctl"
 
+cp "${PACKAGE_ROOT}/tailscale-env" "${WORKDIR}/tailscale-env"
+
 "${ROOT}/package/manage.sh" install; assert "Tailscale installer should run successfully"
 
 cat "${WORKDIR}/apt.args"

--- a/tests/install.2.x.test.sh
+++ b/tests/install.2.x.test.sh
@@ -59,6 +59,7 @@ cp "${PACKAGE_ROOT}/tailscale-env" "${WORKDIR}/tailscale-env"
 "${ROOT}/package/manage.sh" install; assert "Tailscale installer should run successfully"
 
 cat "${WORKDIR}/apt.args"
+cat "${WORKDIR}/sed.args"
 
 assert_contains "$(head -n 1 "${WORKDIR}/apt.args")" "update" "The apt command should be called to update the package list"
 assert_contains "$(head -n 2 "${WORKDIR}/apt.args" | tail -n 1)" "install -y tailscale" "The apt command should be called with the command to install tailscale file"


### PR DESCRIPTION
This PR adds support for propagating the `TAILSCALED_FLAGS` configuration from `tailscale-env` into the `/etc/default/tailscaled` config file when running installation command. This normalizes behaviour across UniFi 1.x and UniFi 2.x installations for the `TAILSCALED_FLAGS` specified in the `tailscale-env` file.

Fixes #69 