### PR TITLE
Fix small typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ helper script.
 
 ##### Using `apt`
 ```sh
-apt update && apt upgrade -y tailscale
+apt update && apt install -y tailscale
 ```
 
 ##### Using `manage.sh`


### PR DESCRIPTION
Was previously upgrading all packages instead of only updating tailscale, because "upgrade" does not allow any package name as parameter.