### PR TITLE
refactor: Improve re-install timer to address OS update issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ tar xzf "${WORKDIR}/tailscale.tgz" -C "$(dirname -- "${PACKAGE_ROOT}")"
 
 # Update tailscale-env with modified values
 if [ -n "${TAILSCALED_FLAGS:-}" ]; then
-  echo "TAILSCALED_FLAGS=\"${TAILSCALED_FLAGS}\"" >> "$package_root/tailscale-env"
+  echo "TAILSCALED_FLAGS=\"${TAILSCALED_FLAGS}\"" >> "$PACKAGE_ROOT/tailscale-env"
 fi
 
 # Run the setup script to ensure that Tailscale is installed

--- a/package/tailscale-install.service
+++ b/package/tailscale-install.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Ensure that Tailscale is installed on your device
 After=network.target
-Requires=mnt-.rwfs.mount
+RequiresMountsFor=/data/tailscale
 Wants=tailscale-install.timer
 
 [Service]

--- a/package/tailscale-install.service
+++ b/package/tailscale-install.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Ensure that Tailscale is installed on your device
 After=network.target
+Requires=mnt-.rwfs.mount
+Wants=tailscale-install.timer
 
 [Service]
 Type=oneshot
-RemainAfterExit=no
-Restart=no
 Environment=DEBIAN_FRONTEND=noninteractive
-ExecStart=/bin/bash /data/tailscale/manage.sh on-boot
+ExecStart=/bin/bash -c "/data/tailscale/manage.sh on-boot"
 
 [Install]
 WantedBy=multi-user.target

--- a/package/tailscale-install.timer
+++ b/package/tailscale-install.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ensure that Tailscale is updated automatically on your device.
+Requires=tailscale-install.service
 
 [Timer]
 OnBootSec=5m
@@ -7,4 +8,4 @@ OnUnitActiveSec=24h
 Unit=tailscale-install.service
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target

--- a/package/unios_2.x.sh
+++ b/package/unios_2.x.sh
@@ -90,9 +90,6 @@ _tailscale_install() {
 
         echo "Installing pre-start script to install Tailscale on firmware updates."
         ln -s "${TAILSCALE_ROOT}/tailscale-install.service" /etc/systemd/system/tailscale-install.service
-
-        systemctl daemon-reload
-        systemctl enable tailscale-install.service
     fi
 
     if [ ! -L "/etc/systemd/system/tailscale-install.timer" ]; then
@@ -102,10 +99,11 @@ _tailscale_install() {
 
         echo "Installing auto-update timer to ensure that Tailscale is kept installed and up to date."
         ln -s "${TAILSCALE_ROOT}/tailscale-install.timer" /etc/systemd/system/tailscale-install.timer
-
-        systemctl daemon-reload
-        systemctl enable --now tailscale-install.timer
     fi
+
+    systemctl daemon-reload
+    systemctl enable tailscale-install.service
+    systemctl enable --now tailscale-install.timer
 
     echo "Installation complete, run '$0 start' to start Tailscale"
 }
@@ -116,4 +114,7 @@ _tailscale_uninstall() {
 
     systemctl disable tailscale-install.service || true
     rm -f /lib/systemd/system/tailscale-install.service || true
+
+    systemctl disable tailscale-install.timer || true
+    rm -f /lib/systemd/system/tailscale-install.timer || true
 }


### PR DESCRIPTION
This PR implements several improvements in an attempt to resolve the OS update issues some folks have been reporting. It does so through three key changes:

1. It adds a `RequiresMountsFor=/data/tailscale` requirement to the `tailscale-install.service` to clarify sequencing requirements for the OS.

2. It updates the install script to ensure that the install timer and service are always enabled after running the installer (to prevent cases where these might have been installed but not enabled).

3. It updates the configuration of the timer and service to provide better linking and follow the recommended systemd timer format for recurring jobs, which should avoid scenarios where the installer might not run correctly.

I have tested this on a UDM, however it has not yet been tested on other devices.