### PR TITLE
fix: restore UniFi certificate database registration

### DIFF
--- a/package/helpers/cert-db-register.sh
+++ b/package/helpers/cert-db-register.sh
@@ -39,12 +39,12 @@ parse_cert_date() {
 
 run_psql() {
     if command -v sudo >/dev/null 2>&1; then
-        sudo -u unifi-core env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -d unifi-core "$@"
+        sudo -u unifi-core env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -d unifi-core
         return $?
     fi
 
     if command -v psql >/dev/null 2>&1; then
-        env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -U unifi-core -d unifi-core "$@"
+        env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -U unifi-core -d unifi-core
         return $?
     fi
 

--- a/package/helpers/cert-db-register.sh
+++ b/package/helpers/cert-db-register.sh
@@ -1,3 +1,161 @@
 #!/bin/sh
-echo "Mock: Registering certificate $1 in database"
-exit 0
+
+set -eu
+
+cert_uuid="${1:-}"
+cert_file="${2:-}"
+key_file="${3:-}"
+hostname="${4:-$(hostname)}"
+
+if [ -z "$cert_uuid" ] || [ -z "$cert_file" ] || [ -z "$key_file" ]; then
+    echo "Usage: $0 <uuid> <cert_file> <key_file> [hostname]"
+    exit 1
+fi
+
+if [ ! -f "$cert_file" ] || [ ! -f "$key_file" ]; then
+    echo "Certificate or key file not found"
+    exit 1
+fi
+
+escape_sql() {
+    sed "s/'/''/g"
+}
+
+parse_cert_date() {
+    cert_date="$1"
+
+    if date -u -d "$cert_date" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1; then
+        date -u -d "$cert_date" "+%Y-%m-%dT%H:%M:%SZ"
+        return 0
+    fi
+
+    if date -j -u -f "%b %e %H:%M:%S %Y %Z" "$cert_date" "+%Y-%m-%dT%H:%M:%SZ" >/dev/null 2>&1; then
+        date -j -u -f "%b %e %H:%M:%S %Y %Z" "$cert_date" "+%Y-%m-%dT%H:%M:%SZ"
+        return 0
+    fi
+
+    return 1
+}
+
+run_psql() {
+    if command -v sudo >/dev/null 2>&1; then
+        sudo -u unifi-core env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -d unifi-core "$@"
+        return $?
+    fi
+
+    if command -v psql >/dev/null 2>&1; then
+        env LANG=C LC_ALL=C psql -v ON_ERROR_STOP=1 -h /run/postgresql -p 5432 -U unifi-core -d unifi-core "$@"
+        return $?
+    fi
+
+    echo "PostgreSQL client not found. Cannot register certificate in database."
+    exit 1
+}
+
+cert_content=$(escape_sql < "$cert_file")
+key_content=$(escape_sql < "$key_file")
+
+valid_from=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+valid_to=$(date -u -v+90d "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "+90 days" "+%Y-%m-%dT%H:%M:%SZ")
+subject_cn="$hostname"
+issuer_cn="Unknown issuer"
+serial_number="0"
+fingerprint="0"
+version="3"
+
+if command -v openssl >/dev/null 2>&1; then
+    not_before=$(openssl x509 -noout -startdate -in "$cert_file" | cut -d= -f2-)
+    not_after=$(openssl x509 -noout -enddate -in "$cert_file" | cut -d= -f2-)
+
+    parsed_valid_from=$(parse_cert_date "$not_before" 2>/dev/null || true)
+    parsed_valid_to=$(parse_cert_date "$not_after" 2>/dev/null || true)
+
+    if [ -n "$parsed_valid_from" ]; then
+        valid_from="$parsed_valid_from"
+    fi
+
+    if [ -n "$parsed_valid_to" ]; then
+        valid_to="$parsed_valid_to"
+    fi
+
+    subject_cn=$(openssl x509 -noout -subject -in "$cert_file" | sed -n 's/.*CN[[:space:]]*=[[:space:]]*\([^,/]*\).*/\1/p')
+    issuer_cn=$(openssl x509 -noout -issuer -in "$cert_file" | sed -n 's/.*CN[[:space:]]*=[[:space:]]*\([^,/]*\).*/\1/p')
+    serial_number=$(openssl x509 -noout -serial -in "$cert_file" | cut -d= -f2-)
+    fingerprint=$(openssl x509 -noout -fingerprint -sha256 -in "$cert_file" | cut -d= -f2- | tr -d ':')
+    version=$(openssl x509 -noout -text -in "$cert_file" | awk '/Version:/{print $2; exit}')
+
+    if [ -z "$subject_cn" ]; then
+        subject_cn="$hostname"
+    fi
+
+    if [ -z "$issuer_cn" ]; then
+        issuer_cn="Unknown issuer"
+    fi
+
+    if [ -z "$serial_number" ]; then
+        serial_number="0"
+    fi
+
+    if [ -z "$fingerprint" ]; then
+        fingerprint="0"
+    fi
+
+    if [ -z "$version" ]; then
+        version="3"
+    fi
+fi
+
+cert_name=$(printf "Tailscale Certificate - %s" "$hostname" | escape_sql)
+subject_cn_escaped=$(printf "%s" "$subject_cn" | escape_sql)
+issuer_cn_escaped=$(printf "%s" "$issuer_cn" | escape_sql)
+hostname_escaped=$(printf "%s" "$hostname" | escape_sql)
+serial_number_escaped=$(printf "%s" "$serial_number" | escape_sql)
+fingerprint_escaped=$(printf "%s" "$fingerprint" | escape_sql)
+
+run_psql <<EOF
+INSERT INTO user_certificates (
+    id,
+    name,
+    key,
+    cert,
+    version,
+    serial_number,
+    fingerprint,
+    subject,
+    issuer,
+    subject_alt_name,
+    valid_from,
+    valid_to,
+    created_at,
+    updated_at
+) VALUES (
+    '$cert_uuid'::uuid,
+    '$cert_name',
+    E'$key_content',
+    E'$cert_content',
+    $version,
+    '$serial_number_escaped',
+    '$fingerprint_escaped',
+    '{"CN":"$subject_cn_escaped"}'::jsonb,
+    '{"CN":"$issuer_cn_escaped"}'::jsonb,
+    '["$hostname_escaped"]'::jsonb,
+    '$valid_from'::timestamp with time zone,
+    '$valid_to'::timestamp with time zone,
+    NOW(),
+    NOW()
+) ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    key = EXCLUDED.key,
+    cert = EXCLUDED.cert,
+    version = EXCLUDED.version,
+    serial_number = EXCLUDED.serial_number,
+    fingerprint = EXCLUDED.fingerprint,
+    subject = EXCLUDED.subject,
+    issuer = EXCLUDED.issuer,
+    subject_alt_name = EXCLUDED.subject_alt_name,
+    valid_from = EXCLUDED.valid_from,
+    valid_to = EXCLUDED.valid_to,
+    updated_at = NOW();
+EOF
+
+echo "Certificate registered in database with UUID: $cert_uuid"

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -286,7 +286,10 @@ tailscale_cert_install_unifi() {
       # Register certificate in PostgreSQL database for persistence
       if [ -f "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" ]; then
           echo "Registering certificate in database..."
-          sh "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" "$cert_uuid" "/data/unifi-core/config/$cert_uuid.crt" "/data/unifi-core/config/$cert_uuid.key" "$TAILSCALE_HOSTNAME"
+          if ! sh "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" "$cert_uuid" "/data/unifi-core/config/$cert_uuid.crt" "/data/unifi-core/config/$cert_uuid.key" "$TAILSCALE_HOSTNAME"; then
+              echo "Failed to register certificate in UniFi database"
+              exit 1
+          fi
       else
           echo "Warning: Database registration script not found. Certificate may not persist across restarts."
       fi

--- a/tests/cert-db.test.sh
+++ b/tests/cert-db.test.sh
@@ -9,76 +9,100 @@ trap 'rm -rf ${WORKDIR}' EXIT
 
 export PATH="${WORKDIR}:${PATH}"
 export TAILSCALE_ROOT="${WORKDIR}"
+export SQL_CAPTURE_PATH="${WORKDIR}/captured.sql"
 
-# Test database registration script
-echo "Testing certificate database registration..."
+cat > "$WORKDIR/openssl" <<'EOF'
+#!/usr/bin/env bash
 
-# Create test certificate and key
+if [ "$1" != "x509" ]; then
+    echo "Unexpected openssl command: $*" >&2
+    exit 1
+fi
+
+shift
+
+case "$1" in
+    -noout)
+        shift
+        case "$1" in
+            -startdate)
+                echo "notBefore=Jul 29 09:27:20 2025 GMT"
+                ;;
+            -enddate)
+                echo "notAfter=Oct 27 09:27:19 2025 GMT"
+                ;;
+            -subject)
+                echo "subject=CN = wandi-gateway.taildb452.ts.net"
+                ;;
+            -issuer)
+                echo "issuer=CN = E5"
+                ;;
+            -serial)
+                echo "serial=1234ABCD"
+                ;;
+            -fingerprint)
+                echo "sha256 Fingerprint=AA:BB:CC:DD"
+                ;;
+            *)
+                echo "Unexpected openssl -noout arguments: $*" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    -text)
+        echo "        Version: 3 (0x2)"
+        ;;
+    *)
+        echo "Unexpected openssl arguments: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$WORKDIR/openssl"
+
+cat > "$WORKDIR/psql" <<'EOF'
+#!/usr/bin/env bash
+cat > "$SQL_CAPTURE_PATH"
+EOF
+chmod +x "$WORKDIR/psql"
+
+cat > "$WORKDIR/sudo" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-u" ]; then
+    shift 2
+fi
+exec "$@"
+EOF
+chmod +x "$WORKDIR/sudo"
+
 cat > "$WORKDIR/test.crt" <<'EOF'
 -----BEGIN CERTIFICATE-----
-MIIDrDCCAzGgAwIBAgISBbD85QuQft/Jp6qlAOSNfxF0MAoGCCqGSM49BAMDMDIx
-CzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQswCQYDVQQDEwJF
-NTAeFw0yNTA3MjkwOTI3MjBaFw0yNTEwMjcwOTI3MTlaMCkxJzAlBgNVBAMTHnVk
-bS1wcm8td2FuZGkudGFpbGRiNDUyLnRzLm5ldDBZMBMGByqGSM49AgEGCCqGSM49
-AwEHA0IABNwmXCgC7McRGNBwjP34VJzTkAMq2jWutgOyPzfYBW/3nO24zSk2Z6Jf
-djYgD35djCyVfDL54uL96XNB8gumM0o=
+MOCK CERTIFICATE
 -----END CERTIFICATE-----
 EOF
 
 cat > "$WORKDIR/test.key" <<'EOF'
------BEGIN EC PRIVATE KEY-----
-MHcCAQEEIBh5+moHGwZBXdqxDsqo8W3SSakNlVFzOhCatdfprOYRoAoGCCqGSM49
-AwEHoUQDQgAE3CZcKALsxxEY0HCM/fhUnNOQAyraNa62A7I/N9gFb/ec7bjNKTZn
-ol92NiAPfl2MLJV8Mvni4v3pc0HyC6YzSg==
------END EC PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
+MOCK PRIVATE KEY
+-----END PRIVATE KEY-----
 EOF
 
-# Test UUID generation
-#test_uuid="12345678-1234-1234-1234-123456789012"
+output=$("${ROOT}/package/helpers/cert-db-register.sh" \
+    "12345678-1234-1234-1234-123456789012" \
+    "$WORKDIR/test.crt" \
+    "$WORKDIR/test.key" \
+    "wandi-gateway.taildb452.ts.net" 2>&1)
 
-# Test certificate content extraction
-if command -v openssl >/dev/null 2>&1; then
-    # Extract subject CN
-    subject=$(openssl x509 -noout -subject -in "$WORKDIR/test.crt" 2>/dev/null || echo "")
-    if [ -n "$subject" ]; then
-        assert_contains "$subject" "CN" "Certificate subject contains CN"
-    fi
+assert_contains "$output" "Certificate registered in database with UUID: 12345678-1234-1234-1234-123456789012" "Helper reports successful registration"
 
-    # Extract dates
-    not_after=$(openssl x509 -noout -enddate -in "$WORKDIR/test.crt" 2>/dev/null || echo "")
-    if [ -n "$not_after" ]; then
-        assert_contains "$not_after" "notAfter" "Certificate has expiry date"
-    fi
-fi
-
-# Test SQL generation (mock)
-# Using a more portable sed command for macOS
-cert_content=$(awk '{printf "%s\\n", $0}' "$WORKDIR/test.crt" | sed 's/\\n$//')
-key_content=$(awk '{printf "%s\\n", $0}' "$WORKDIR/test.key" | sed 's/\\n$//')
-
-# Verify content transformation
-assert_contains "$cert_content" "BEGIN CERTIFICATE" "Certificate content includes header"
-assert_contains "$key_content" "BEGIN EC PRIVATE KEY" "Key content includes header"
-
-# Test install-unifi with database registration
-echo "Testing install-unifi with database registration..."
-
-# Create mock certificate files
-mkdir -p "$TAILSCALE_ROOT/certs"
-echo "MOCK CERTIFICATE" > "$TAILSCALE_ROOT/certs/test-host.crt"
-echo "MOCK PRIVATE KEY" > "$TAILSCALE_ROOT/certs/test-host.key"
-
-# Create mock database registration script
-cat > "$ROOT/package/helpers/cert-db-register.sh" <<'EOF'
-#!/bin/sh
-echo "Mock: Registering certificate $1 in database"
-exit 0
-EOF
-chmod +x "$ROOT/package/helpers/cert-db-register.sh"
-
-# Test that database registration script exists
-if [ -f "$ROOT/package/helpers/cert-db-register.sh" ]; then
-    assert_eq "0" "0" "Database registration script exists"
-fi
+captured_sql=$(cat "$SQL_CAPTURE_PATH")
+assert_contains "$captured_sql" "INSERT INTO user_certificates" "Generated SQL inserts into user_certificates"
+assert_contains "$captured_sql" "12345678-1234-1234-1234-123456789012" "Generated SQL includes the certificate UUID"
+assert_contains "$captured_sql" "Tailscale Certificate - wandi-gateway.taildb452.ts.net" "Generated SQL includes the certificate name"
+assert_contains "$captured_sql" '"CN":"wandi-gateway.taildb452.ts.net"' "Generated SQL includes the subject CN"
+assert_contains "$captured_sql" '"CN":"E5"' "Generated SQL includes the issuer CN"
+assert_contains "$captured_sql" "AABBCCDD" "Generated SQL normalizes the SHA256 fingerprint"
+assert_contains "$captured_sql" "MOCK CERTIFICATE" "Generated SQL includes the certificate body"
+assert_contains "$captured_sql" "MOCK PRIVATE KEY" "Generated SQL includes the private key body"
 
 echo "All certificate database tests passed!"

--- a/tests/cert.test.sh
+++ b/tests/cert.test.sh
@@ -70,7 +70,11 @@ case "\$1" in
         ;;
     status)
         if [ "\$2" = "--json" ]; then
-            echo '{"BackendState": "Running", "Self": {"DNSName": "test-host.example.ts.net."}}'
+            if [ -f "${WORKDIR}/tailscaled.sock" ]; then
+                echo '{"BackendState": "Running", "Self": {"DNSName": "test-host.example.ts.net."}}'
+            else
+                echo '{"BackendState": "Stopped", "Self": {"DNSName": "test-host.example.ts.net."}}'
+            fi
         fi
         ;;
     *)
@@ -147,6 +151,7 @@ test_cert_not_running() {
 
     # Test generate when not running
     output=$("${ROOT}/package/manage.sh" cert generate 2>&1 || true)
+    assert_contains "$output" "Tailscale is not running" "Output contains not running message"
 }
 
 # Test help command

--- a/tests/status.test.sh
+++ b/tests/status.test.sh
@@ -12,7 +12,7 @@ export PACKAGE_ROOT="${ROOT}/package"
 export TAILSCALE_ROOT="${WORKDIR}"
 export TAILSCALED_SOCK="${WORKDIR}/tailscaled.sock"
 
-export PATH="${WORKDIR}:${PATH}"
+export PATH="${WORKDIR}:/usr/bin:/bin:/usr/sbin:/sbin"
 mock "${WORKDIR}/ubnt-device-info" "2.0.0"
 mock "${WORKDIR}/systemctl" "" 1
 


### PR DESCRIPTION
## Summary

Restores `cert install-unifi` on current UniFi OS releases by replacing the mock `cert-db-register.sh` helper with a real PostgreSQL registration step.

This fixes the regression tracked in #171, where `cert install-unifi` reported success but UniFi continued serving the default self-signed certificate because the certificate was never registered in `user_certificates`.

This is effectively a restoration of the working UniFi OS certificate registration path from #117, which appears to have been lost during later refactoring.

## What changed

- replace the mock `package/helpers/cert-db-register.sh` helper with a real PostgreSQL upsert into `user_certificates`
- extract certificate metadata with `openssl` so the inserted row matches UniFi’s expected schema
- run `psql` with `ON_ERROR_STOP=1` and `LANG=C LC_ALL=C` for cleaner, fail-fast execution on-device
- make `package/manage.sh cert install-unifi` fail if database registration fails instead of reporting a false success
- update the certificate database test to verify the generated SQL and metadata
- fix the certificate/status tests so they behave consistently in environments where a real `tailscale` binary is present

## Why this approach

I also investigated the file/config override approach used by[ GlennR’s UniFi Let's Encrypt tooling](https://glennr.nl/s/unifi-lets-encrypt).

That path appears to be built around RSA certs, while `tailscale cert` currently produces ECDSA certs. In live testing on UniFi OS 5, the override-based path did not hold the Tailscale certificate, while the `user_certificates` registration path worked correctly with the exact same cert.

Given that, restoring the database registration logic is the smallest verified fix for Tailscale-issued certs on UniFi OS 5.

## Testing

- `bash tests/run.sh`

## Manual verification

Tested on a UDM Pro Max running UniFi OS 5, where:

1. `cert install-unifi` registered the Tailscale certificate in `user_certificates`
2. restarting `unifi-core` caused the console to serve the Tailscale Let's Encrypt certificate
3. the `.ts.net` hostname presented the expected certificate instead of `unifi.local`
