### PR TITLE
feat: detect OS version on UNVR-G2 (UNVRAI)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,8 @@ elif [ -f "/usr/lib/version" ]; then
     OS_VERSION="$(sed -e 's/UNVRPRO.*.v\(.\)\..*/\1/' /usr/lib/version)"
   elif [ "$(grep -c '^UNVR4.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
     OS_VERSION="$(sed -e 's/UNVR4.*.v\(.\)\..*/\1/' /usr/lib/version)"
+  elif [ "$(grep -c '^UNVRAI.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
+    OS_VERSION="$(sed -e 's/UNVRAI.*.v\(.\)\..*/\1/' /usr/lib/version)"
   else
     echo "Could not detect OS Version.  /usr/lib/version contains:"
     cat /usr/lib/version

--- a/package/on-boot.sh
+++ b/package/on-boot.sh
@@ -20,6 +20,8 @@ elif [ -f "/usr/lib/version" ]; then
     OS_VERSION="$(sed -e 's/UCKG2.*.v\(.\)\..*/\1/' /usr/lib/version)"
   elif [ "$(grep -c '^UNASPRO.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
     OS_VERSION="$(sed -e 's/UNASPRO.*.v\(.\)\..*/\1/' /usr/lib/version)"
+  elif [ "$(grep -c '^UNVRAI.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
+    OS_VERSION="$(sed -e 's/UNVRAI.*.v\(.\)\..*/\1/' /usr/lib/version)"
   else
     echo "Could not detect OS Version.  /usr/lib/version contains:"
     cat /usr/lib/version


### PR DESCRIPTION
Adds support for detecting the OS version on the UNVR-G2, which is identified by the `UNVRAI` prefix in  `/usr/lib/version`.

Was able to install it on my UNVR-G2 and verify it worked with my tailnet.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with your device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/SierraSoftworks/tailscale-unifi#contributing) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/SierraSoftworks/tailscale-unifi/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests (excluding integration tests) for your changes (if applicable)?
- [x] Have you successfully run your changes locally?

---

- [ ] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes_. Non-maintainers may only have one AI-assisted/generated PR open at a time.

---
