### PR TITLE
fix: Harden install recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,6 @@ You do this by updating your Tailscale configuration as you would on any other m
 
 ```sh
 # Specify the routes you'd like to advertise using their CIDR notation
-
-# UniFi OS 1.x
-/mnt/data/tailscale/tailscale up --advertise-routes="10.0.0.0/24,192.168.0.0/24"
-
-# UniFi OS 2.x/3.x
 tailscale up --advertise-routes="10.0.0.0/24,192.168.0.0/24"
 ```
 
@@ -206,14 +201,6 @@ If you are running an older version of tailscale-udm, you can switch to TUN mode
 You bet, make sure you're running the latest version of Tailscale and then run `tailscale up --ssh` to enable it. You'll need to set up SSH ACLs in your account by following [this guide](https://tailscale.com/kb/1193/tailscale-ssh/).
 
 ```sh
-# UniFi OS 1.x
-# Update Tailscale to its latest version
-/mnt/data/tailscale/manage.sh update!
-
-# Enable SSH advertisement through Tailscale
-/mnt/data/tailscale/tailscale up --ssh
-
-# UniFi OS 2.x/3.x
 # Update Tailscale to its latest version
 /data/tailscale/manage.sh update!
 

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -52,8 +52,6 @@ tailscale_stop() {
 # the copied regular files are readable by systemd on every boot even before
 # /ssd1 is mounted -- which is what lets RequiresMountsFor= in the unit be
 # honoured at all.
-#
-# Sets SYSTEMD_UNITS_CHANGED=1 when it modifies the destination.
 install_systemd_unit() {
   _unit="$1"
   _src="${PACKAGE_ROOT}/${_unit}"
@@ -65,7 +63,6 @@ install_systemd_unit() {
   if [ -L "$_dst" ] || [ ! -f "$_dst" ] || ! cmp -s "$_src" "$_dst"; then
     rm -f "$_dst"
     cp "$_src" "$_dst"
-    SYSTEMD_UNITS_CHANGED=1
   fi
 }
 
@@ -79,17 +76,13 @@ install_systemd_unit() {
 # plain files while the system is healthy, before the next firmware update makes
 # them unreadable to systemd.
 ensure_systemd_units() {
-  SYSTEMD_UNITS_CHANGED=""
-
+  echo "Installing systemd units to keep Tailscale installed across firmware updates."
   install_systemd_unit tailscale-install.service
   install_systemd_unit tailscale-install.timer
-
-  if [ -n "$SYSTEMD_UNITS_CHANGED" ]; then
-    echo "Installing systemd units to keep Tailscale installed across firmware updates."
-    systemctl daemon-reload
-    systemctl enable tailscale-install.service
-    systemctl enable --now tailscale-install.timer
-  fi
+  
+  systemctl daemon-reload
+  systemctl enable tailscale-install.service
+  systemctl enable --now tailscale-install.timer
 }
 
 tailscale_install() {

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -69,8 +69,7 @@ install_systemd_unit() {
 # ensure_systemd_units
 #
 # Install (or repair) the units that reinstall Tailscale after a firmware update,
-# and make sure they are enabled.  Safe to run on every boot: it only reloads and
-# enables when a unit actually changed, so a healthy device incurs no churn.
+# and make sure they are enabled.
 # Running it unconditionally (not only when Tailscale is missing) is what lets old
 # symlink-based installs heal themselves -- the stale symlinks are rewritten as
 # plain files while the system is healthy, before the next firmware update makes

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -38,6 +38,60 @@ tailscale_stop() {
   systemctl stop tailscaled
 }
 
+# install_systemd_unit <unit-file-name>
+#
+# Copy ${PACKAGE_ROOT}/<unit> to ${SYSTEMD_UNIT_DIR}/<unit>, but only when the
+# destination is missing, is a symlink, or differs from the packaged copy.
+#
+# A plain `cp -f` does NOT pre-unlink its destination; it only retries the open
+# on failure.  On UDM-SE /data -> /ssd1/.data, so a pre-v3.3.0 symlink at
+# ${SYSTEMD_UNIT_DIR}/<unit> pointing back into /data/tailscale/ makes the source
+# and destination canonicalise to the same inode and `cp` aborts with "are the
+# same file".  Removing the destination first handles symlinks, hard-links and
+# regular files uniformly.  /etc lives on the overlay root (always mounted), so
+# the copied regular files are readable by systemd on every boot even before
+# /ssd1 is mounted -- which is what lets RequiresMountsFor= in the unit be
+# honoured at all.
+#
+# Sets SYSTEMD_UNITS_CHANGED=1 when it modifies the destination.
+install_systemd_unit() {
+  _unit="$1"
+  _src="${PACKAGE_ROOT}/${_unit}"
+  _dst="${SYSTEMD_UNIT_DIR}/${_unit}"
+
+  # Nothing to do if the package does not ship this unit.
+  [ -f "$_src" ] || return 0
+
+  if [ -L "$_dst" ] || [ ! -f "$_dst" ] || ! cmp -s "$_src" "$_dst"; then
+    rm -f "$_dst"
+    cp "$_src" "$_dst"
+    SYSTEMD_UNITS_CHANGED=1
+  fi
+}
+
+# ensure_systemd_units
+#
+# Install (or repair) the units that reinstall Tailscale after a firmware update,
+# and make sure they are enabled.  Safe to run on every boot: it only reloads and
+# enables when a unit actually changed, so a healthy device incurs no churn.
+# Running it unconditionally (not only when Tailscale is missing) is what lets old
+# symlink-based installs heal themselves -- the stale symlinks are rewritten as
+# plain files while the system is healthy, before the next firmware update makes
+# them unreadable to systemd.
+ensure_systemd_units() {
+  SYSTEMD_UNITS_CHANGED=""
+
+  install_systemd_unit tailscale-install.service
+  install_systemd_unit tailscale-install.timer
+
+  if [ -n "$SYSTEMD_UNITS_CHANGED" ]; then
+    echo "Installing systemd units to keep Tailscale installed across firmware updates."
+    systemctl daemon-reload
+    systemctl enable tailscale-install.service
+    systemctl enable --now tailscale-install.timer
+  fi
+}
+
 tailscale_install() {
   # shellcheck source=tests/os-release
   . "${OS_RELEASE_FILE:-/etc/os-release}"
@@ -97,26 +151,9 @@ tailscale_install() {
       exit 1
   }
 
-  # Remove any pre-existing file or symlink at the destination before copying.
-  # A plain `cp -f` does NOT pre-unlink the destination; it only retries if the
-  # open fails.  On UDM-SE /data -> /ssd1/.data, so a v3.2.0 symlink at
-  # ${SYSTEMD_UNIT_DIR}/tailscale-install.{service,timer} pointing back into
-  # /data/tailscale/ causes both source and destination to canonicalise to the
-  # same inode, and cp aborts with "are the same file".  Explicitly removing the
-  # destination first handles symlinks, hard-links, and regular files uniformly.
-  # /etc lives on the overlay root (always mounted), so the copied regular files
-  # are visible to systemd on every boot even before /ssd1 is mounted.
-  echo "Installing pre-start script to install Tailscale on firmware updates."
-  rm -f "${SYSTEMD_UNIT_DIR}/tailscale-install.service"
-  cp "${PACKAGE_ROOT}/tailscale-install.service" "${SYSTEMD_UNIT_DIR}/tailscale-install.service"
-
-  echo "Installing auto-update timer to ensure that Tailscale is kept installed and up to date."
-  rm -f "${SYSTEMD_UNIT_DIR}/tailscale-install.timer"
-  cp "${PACKAGE_ROOT}/tailscale-install.timer" "${SYSTEMD_UNIT_DIR}/tailscale-install.timer"
-
-  systemctl daemon-reload
-  systemctl enable tailscale-install.service
-  systemctl enable --now tailscale-install.timer
+  # Install (or repair) the systemd units that reinstall Tailscale after a
+  # firmware update.  See ensure_systemd_units / install_systemd_unit above.
+  ensure_systemd_units
 
   echo "Installation complete, run '$0 start' to start Tailscale"
 }
@@ -139,6 +176,13 @@ tailscale_uninstall() {
 }
 
 tailscale_has_update() {
+  # If Tailscale isn't installed there is nothing to compare against; report
+  # "needs install" without the noisy "tailscale: not found" on stderr (this is
+  # what `manage.sh update` hits on a device whose binaries were just wiped).
+  if ! command -v tailscale >/dev/null 2>&1; then
+    return 0
+  fi
+
   CURRENT_VERSION="$(tailscale --version | head -n 1)"
   TARGET_VERSION="${1:-$(curl --ipv4 -sSLq 'https://pkgs.tailscale.com/stable/?mode=json' | jq -r '.Tarballs.arm64 | capture("tailscale_(?<version>[^_]+)_").version')}"
 
@@ -185,14 +229,12 @@ tailscale_cert_generate() {
       echo ""
       echo "Certificate expires in 90 days. Use '$0 cert renew $TAILSCALE_HOSTNAME' to renew."
 
-      # Remove any pre-existing file or symlink before copying (see comment in
-      # tailscale_install for the full explanation of why rm -f is required).
+      # Install (or repair) the cert-renewal units.  install_systemd_unit removes
+      # any pre-existing symlink before copying (see its comment for why).
       if [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.service" ] && [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" ]; then
           echo "Installing certificate auto-renewal timer..."
-          rm -f "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.service"
-          cp "${PACKAGE_ROOT}/tailscale-cert-renewal.service" "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.service"
-          rm -f "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.timer"
-          cp "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.timer"
+          install_systemd_unit tailscale-cert-renewal.service
+          install_systemd_unit tailscale-cert-renewal.timer
           systemctl daemon-reload
           systemctl enable tailscale-cert-renewal.timer
           systemctl start tailscale-cert-renewal.timer
@@ -438,6 +480,15 @@ case $1 in
   "on-boot")
     # shellcheck source=package/tailscale-env
     . "${PACKAGE_ROOT}/tailscale-env"
+
+    # Repair the systemd units first, on every boot, even when Tailscale is
+    # already installed and healthy.  This rewrites any stale symlinked unit
+    # files (from installs predating the copy-based layout) as plain regular
+    # files in /etc while the disk is mounted, so the auto-reinstall units stay
+    # readable by systemd after the next firmware update wipes /usr.  Doing it
+    # first means the units are healthy for the next boot even if the steps
+    # below fail.
+    ensure_systemd_units
 
     if ! command -v tailscale >/dev/null 2>&1; then
       tailscale_install

--- a/package/on-boot.sh
+++ b/package/on-boot.sh
@@ -1,42 +1,14 @@
 #!/bin/bash
 set -e
 
-if [ -x "$(which ubnt-device-info)" ]; then
-  OS_VERSION="${FW_VERSION:-$(ubnt-device-info firmware_detail | grep -oE '^[0-9]+')}"
-elif [ -f "/usr/lib/version" ]; then
-  # UCKP == Unifi CloudKey Gen2 Plus
-  # example /usr/lib/version file contents:
-  # UCKP.apq8053.v2.5.11.b2ebfc7.220801.1419
-  # UCKP.apq8053.v3.0.17.8102bbc.230210.1526
-  # UCKG2 == UniFi CloudKey Gen2
-  # example /usr/lib/version file contents:
-  # UCKG2.apq8053.v3.1.13.3584673.230626.2239
-  # UNASPRO == Unas Pro
-  # example /usr/lib/version file contents:
-  # UNASPRO.al324.v4.2.9.3ec2ce6.250417.1324
-  if [ "$(grep -c '^UCKP.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
-    OS_VERSION="$(sed -e 's/UCKP.*.v\(.\)\..*/\1/' /usr/lib/version)"
-  elif [ "$(grep -c '^UCKG2.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
-    OS_VERSION="$(sed -e 's/UCKG2.*.v\(.\)\..*/\1/' /usr/lib/version)"
-  elif [ "$(grep -c '^UNASPRO.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
-    OS_VERSION="$(sed -e 's/UNASPRO.*.v\(.\)\..*/\1/' /usr/lib/version)"
-  elif [ "$(grep -c '^UNVRAI.*\.v[0-9]\.' /usr/lib/version)" = '1' ]; then
-    OS_VERSION="$(sed -e 's/UNVRAI.*.v\(.\)\..*/\1/' /usr/lib/version)"
-  else
-    echo "Could not detect OS Version.  /usr/lib/version contains:"
-    cat /usr/lib/version
-    exit 1
-  fi
-else
-  echo "Could not detect OS Version.  No ubnt-device-info, no version file."
-  exit 1
-fi
-
-
-if [ "$OS_VERSION" = '1' ]; then
-  TAILSCALE_ROOT="/mnt/data/tailscale"
-else
-  TAILSCALE_ROOT="/data/tailscale"
-fi
-
-$TAILSCALE_ROOT/manage.sh on-boot
+# Legacy boot hook for unifi-common / udm-boot setups.  This script is packaged
+# as on_boot.d/10-tailscaled.sh and runs at boot on devices that execute the
+# /data/on_boot.d scripts.  It is a best-effort fallback only; the primary
+# mechanism for keeping Tailscale installed across firmware updates is the
+# systemd tailscale-install.service/.timer that manage.sh installs.
+#
+# All of the boot-time logic (unit repair, reinstall, update, start) lives in
+# manage.sh's "on-boot" handler, so this just delegates to it instead of
+# duplicating OS detection.  UniFi OS 1.x (which used /mnt/data) is no longer
+# supported.
+exec /data/tailscale/manage.sh on-boot

--- a/package/tailscale-cert-renewal.service
+++ b/package/tailscale-cert-renewal.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=Tailscale Certificate Renewal
-After=network.target tailscaled.service
+# `tailscale cert` needs the daemon running and real outbound connectivity, and
+# the script + certs live under /data, so wait for the daemon, the network and
+# the data mount before running (consistent with tailscale-install.service).
+Wants=network-online.target
+After=network-online.target tailscaled.service
+RequiresMountsFor=/data/tailscale
 
 [Service]
 Type=oneshot

--- a/package/tailscale-cert-renewal.timer
+++ b/package/tailscale-cert-renewal.timer
@@ -1,6 +1,5 @@
 [Unit]
 Description=Tailscale Certificate Renewal Timer
-Requires=tailscale-cert-renewal.service
 
 [Timer]
 Unit=tailscale-cert-renewal.service

--- a/package/tailscale-install.service
+++ b/package/tailscale-install.service
@@ -1,18 +1,31 @@
 [Unit]
 Description=Ensure that Tailscale is installed on your device
-After=network.target
+# We need real outbound connectivity (DNS + HTTPS to pkgs.tailscale.com and the
+# apt mirrors), not just a configured interface, so order after
+# network-online.target rather than the passive network.target.  This only
+# delays startup if a wait-online service is active; the Restart= retry below is
+# the real backstop for the connectivity race.
+Wants=network-online.target
+After=network-online.target
+# Wait for /data (on UDM-SE this is /ssd1/.data, mounted late in boot) before
+# running.  systemd can only honour this if it can read this unit file at early
+# boot, which is why manage.sh copies it as a plain regular file into /etc
+# (always mounted) instead of symlinking it into /data.
 RequiresMountsFor=/data/tailscale
-Wants=tailscale-install.timer
+# Retry every 5 minutes until a run succeeds.  StartLimitIntervalSec=0 disables
+# systemd's start rate limiter so the unit never gives up (e.g. while the disk is
+# still mounting or the network is still coming up); together with the
+# Restart=on-failure / RestartSec=5m below it retries indefinitely and stops as
+# soon as a run exits cleanly.  This key MUST live in [Unit]: in [Service] it is
+# silently ignored and the default 5-starts-per-10s limit applies instead.
+StartLimitIntervalSec=0
 
 [Service]
 Type=oneshot
 Environment=DEBIAN_FRONTEND=noninteractive
 ExecStart=/bin/bash -c "/data/tailscale/manage.sh on-boot"
-# Retry every 5 minutes on failure, up to 24 hours
 Restart=on-failure
 RestartSec=5m
-StartLimitIntervalSec=24h
-StartLimitBurst=288
 
 [Install]
 WantedBy=multi-user.target

--- a/package/tailscale-install.timer
+++ b/package/tailscale-install.timer
@@ -1,9 +1,12 @@
 [Unit]
 Description=Ensure that Tailscale is updated automatically on your device.
-Requires=tailscale-install.service
 
 [Timer]
-OnBootSec=5m
+# Trigger shortly after boot and then at least once a day, so Tailscale is kept
+# up to date and reinstalled if a firmware update wiped it.  Transient boot-time
+# failures (disk or network not ready yet) are handled by the service's own
+# 5-minute Restart= retry rather than by the timer.
+OnBootSec=2m
 OnUnitActiveSec=24h
 Unit=tailscale-install.service
 

--- a/tests/helpers.sh
+++ b/tests/helpers.sh
@@ -58,6 +58,22 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local ACTUAL_OUTPUT="${1?You must specify the actual output first argument}"
+    local EXPECTED_OUTPUT="${2?You must specify the expected output as the second argument}"
+    local TEST_NAME="${3?You must specify the test name as the third argument}"
+
+    if (echo "$ACTUAL_OUTPUT" | grep -qe "$EXPECTED_OUTPUT"); then
+        echo "  ❌  $TEST_NAME"
+        echo "    Should Not Contain: $EXPECTED_OUTPUT"
+        echo "    Actual:             $ACTUAL_OUTPUT"
+        echo ""
+        exit 1
+    else
+        echo "  ✅  $TEST_NAME"
+    fi
+}
+
 mock() {
     local MOCK_PATH="${1?You must specify the path to the mock file as the first argument}"
     local OUTPUT="${2-mocked output}"
@@ -75,4 +91,10 @@ exit $EXIT_CODE
 EOF
 
     chmod +x "$MOCK_PATH"
+}
+
+reset_mock() {
+    local MOCK_PATH="${1?You must specify the path to the mock file as the first argument}"
+
+    rm -f "${MOCK_PATH}.args"
 }

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -156,10 +156,12 @@ cmp -s "${PACKAGE_ROOT}/tailscale-install.service" "${SYSTEMD_UNIT_DIR}/tailscal
 [[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.timer" ]]; assert "on-boot rewrites a symlinked tailscale-install.timer as a regular file while Tailscale is healthy"
 [[ -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "on-boot runs daemon-reload after repairing stale units"
 
-# ── on-boot is idempotent: no daemon-reload when units already correct ────────
-rm -f "${WORKDIR}/systemctl.daemon-reload"
-
+# ── on-boot is safe to run repeatedly ─────────────────────────────────────────
+# A second on-boot with the units already correct must still succeed and leave
+# them as regular files matching the package (install_systemd_unit only re-copies
+# a unit when it actually differs, so repeated runs don't corrupt the files).
 "${ROOT}/package/manage.sh" on-boot; assert "second on-boot succeeds and is idempotent"
 
-[[ ! -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "on-boot does not daemon-reload when the units are already correct regular files"
-[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.service" ]]; assert "tailscale-install.service stays a regular file after an idempotent on-boot"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.service" ]]; assert "tailscale-install.service stays a regular file after a repeated on-boot"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.timer" ]]; assert "tailscale-install.timer stays a regular file after a repeated on-boot"
+cmp -s "${PACKAGE_ROOT}/tailscale-install.service" "${SYSTEMD_UNIT_DIR}/tailscale-install.service"; assert "tailscale-install.service still matches the package after a repeated on-boot"

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -110,9 +110,10 @@ ln -sf "${PACKAGE_ROOT}/tailscale-install.timer" \
 # emitted.  curl/jq are mocked empty so the version probe stays offline.
 mock "${WORKDIR}/curl" ""
 mock "${WORKDIR}/jq" ""
+reset_mock "${WORKDIR}/apt"
 
 update_out=$("${ROOT}/package/manage.sh" update 2>&1) || true
-! echo "$update_out" | grep -q "tailscale: not found"; assert "update with tailscale absent does not emit 'tailscale: not found'"
+assert_not_contains "$update_out" "tailscale: not found" "update with tailscale absent does not emit 'tailscale: not found'"
 assert_contains "$(cat "${WORKDIR}/apt.args")" "install -y tailscale" "update with tailscale absent triggers an install"
 
 # ── on-boot repairs stale units while Tailscale is healthy ────────────────────

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -8,7 +8,9 @@ trap 'rm -rf ${WORKDIR}' EXIT
 # shellcheck source=tests/helpers.sh
 . "${ROOT}/tests/helpers.sh"
 
-export PACKAGE_ROOT="${ROOT}/package"
+# Absolute so the symlink fixtures below resolve from any working directory.
+PACKAGE_ROOT="$(cd "${ROOT}/package" && pwd)"
+export PACKAGE_ROOT
 export TAILSCALE_ROOT="${WORKDIR}"
 export TAILSCALED_SOCK="${WORKDIR}/tailscaled.sock"
 export SYSTEMD_UNIT_DIR="${WORKDIR}/systemd"
@@ -21,8 +23,10 @@ mock "${WORKDIR}/apt-key" "--## apt-key mock: \$* ##--"
 mock "${WORKDIR}/tee" "--## tee mock: \$* ##--"
 mock "${WORKDIR}/apt" "--## apt mock: \$* ##--"
 mock "${WORKDIR}/sed" "--## sed mock: \$* ##--"
-mock "${WORKDIR}/ln" "--## ln mock: \$* ##--"
 mock "${WORKDIR}/ubnt-device-info" "2.0.0"
+# NB: `ln` is deliberately NOT mocked.  manage.sh no longer creates symlinks
+# (it copies unit files), so the only `ln` calls are the symlink fixtures the
+# tests below set up — those must use the real `ln` to be meaningful.
 
 # systemctl mock, used to ensure the installer doesn't block thinking that tailscale is running
 cat > "${WORKDIR}/systemctl" <<EOF
@@ -98,3 +102,63 @@ ln -sf "${PACKAGE_ROOT}/tailscale-install.timer" \
 # destination would still appear as a file — only -L distinguishes the two.
 [[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.service" ]]; assert "tailscale-install.service should be a regular file after upgrade, not a symlink"
 [[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.timer" ]]; assert "tailscale-install.timer should be a regular file after upgrade, not a symlink"
+
+# ── update with the tailscale binary absent => clean "needs install" ──────────
+# A device whose binaries were just wiped by a firmware update has no `tailscale`
+# on PATH.  `manage.sh update` must treat that as "needs install" and reinstall,
+# without the noisy "tailscale: not found" that the old tailscale_has_update
+# emitted.  curl/jq are mocked empty so the version probe stays offline.
+mock "${WORKDIR}/curl" ""
+mock "${WORKDIR}/jq" ""
+
+update_out=$("${ROOT}/package/manage.sh" update 2>&1) || true
+! echo "$update_out" | grep -q "tailscale: not found"; assert "update with tailscale absent does not emit 'tailscale: not found'"
+assert_contains "$(cat "${WORKDIR}/apt.args")" "install -y tailscale" "update with tailscale absent triggers an install"
+
+# ── on-boot repairs stale units while Tailscale is healthy ────────────────────
+# The core regression fix: installs predating the copy-based layout leave unit
+# files that drift from the package — symlinks into /data (unreadable at early
+# boot), or stale copies from an older version.  on-boot must repair them on
+# EVERY boot, even when Tailscale is already installed and running, so they are
+# healthy before the next firmware update.  Re-mock systemctl so Tailscale
+# appears installed AND running, and handle the `start` issued by tailscale_start.
+cat > "${WORKDIR}/systemctl" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    "is-active")     exit 0 ;;
+    "is-enabled")    exit 0 ;;
+    "enable")        touch "${WORKDIR}/\$2.enabled" ;;
+    "daemon-reload") touch "${WORKDIR}/systemctl.daemon-reload" ;;
+    "start")         touch "${WORKDIR}/tailscaled.started" ;;
+    "restart")       touch "${WORKDIR}/tailscaled.restarted" ;;
+    *) echo "Unexpected command: \${1}"; exit 1 ;;
+esac
+EOF
+chmod +x "${WORKDIR}/systemctl"
+
+# tailscale present on PATH (command -v succeeds) and reporting a version; sleep
+# instant so tailscale_start doesn't stall the suite.
+mock "${WORKDIR}/tailscale" "1.999.0"
+mock "${WORKDIR}/sleep" ""
+
+# A stale regular unit file (content differs from the package) plus a symlinked
+# unit (the pre-v3.3.0 layout).  The stale-content case drives the change
+# detection portably; the symlink case mirrors the real-world bug.
+printf '[Unit]\n# stale\n' > "${SYSTEMD_UNIT_DIR}/tailscale-install.service"
+ln -sf "${PACKAGE_ROOT}/tailscale-install.timer" \
+       "${SYSTEMD_UNIT_DIR}/tailscale-install.timer"
+rm -f "${WORKDIR}/systemctl.daemon-reload"
+
+"${ROOT}/package/manage.sh" on-boot; assert "on-boot succeeds when Tailscale is already installed"
+
+cmp -s "${PACKAGE_ROOT}/tailscale-install.service" "${SYSTEMD_UNIT_DIR}/tailscale-install.service"; assert "on-boot rewrites a stale tailscale-install.service to match the package while Tailscale is healthy"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.timer" ]]; assert "on-boot rewrites a symlinked tailscale-install.timer as a regular file while Tailscale is healthy"
+[[ -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "on-boot runs daemon-reload after repairing stale units"
+
+# ── on-boot is idempotent: no daemon-reload when units already correct ────────
+rm -f "${WORKDIR}/systemctl.daemon-reload"
+
+"${ROOT}/package/manage.sh" on-boot; assert "second on-boot succeeds and is idempotent"
+
+[[ ! -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "on-boot does not daemon-reload when the units are already correct regular files"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.service" ]]; assert "tailscale-install.service stays a regular file after an idempotent on-boot"


### PR DESCRIPTION
-----

This PR makes a series of improvements to the `manage.sh` script and its associated `*.service` entries to help reduce the likelihood of failures such as those described in #186.

Specifically:

 - It migrates the `tailscale-install.service` to a plain file rather than a symlink, which should resolve issues with `systemd` not being able to resolve the unit at boot (and thus not honouring the `RequiresMountsFor=/data/tailscale` directive).
 - It resolves a misconfiguration of the systemd units which prevented them from retrying a failed installation as originally intended.
 - It does some code refactoring to make future systemd unit installs easier and more robust.

I used Claude to help review the systemd units for potential issues (such as the retry problem) and to write the tests which are included here.

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with your device pointer after creation -->

- [x] Have you followed the guidelines in our [Contributing](https://github.com/SierraSoftworks/tailscale-unifi#contributing) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/SierraSoftworks/tailscale-unifi/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes (if applicable)?
- [x] Have you successfully run your changes locally?

---

- [x] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes_. Non-maintainers may only have one AI-assisted/generated PR open at a time.

---
