### PR TITLE
Sync tailscaled environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ If you have an idea for how this can be improved, please create a [PR](https://g
 
 ## Frequently Asked Questions
 
+### How do I configure environment variables for tailscaled?
+
+Add any `TS_` environment variables to `/data/tailscale/tailscale-env`. For example:
+
+```sh
+TS_TUN_DISABLE_TCP_GRO=1
+```
+
+Then run `/data/tailscale/manage.sh install`. The installer replaces the managed environment section in `/etc/default/tailscaled` and restarts the `tailscaled` service with the new configuration. Removing a `TS_` entry from `tailscale-env` and running the installer again also removes it from the managed section.
+
 ### How do I advertise routes?
 
 Set your Tailscale configuration as you would on any other machine.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Add any `TS_` environment variables to `/data/tailscale/tailscale-env`. For exam
 TS_TUN_DISABLE_TCP_GRO=1
 ```
 
-Then run `/data/tailscale/manage.sh install`. The installer replaces the managed environment section in `/etc/default/tailscaled` and restarts the `tailscaled` service with the new configuration. Removing a `TS_` entry from `tailscale-env` and running the installer again also removes it from the managed section.
+Then run `/data/tailscale/manage.sh install`. The installer replaces the managed environment section in `/etc/default/tailscaled` (and removes/overwrites any existing `TS_*` entries there) and restarts the `tailscaled` service with the new configuration. Removing a `TS_` entry from `tailscale-env` and running the installer again also removes it from the managed section.
 
 ### How do I advertise routes?
 

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -93,7 +93,9 @@ sync_tailscaled_environment() {
   sed -i '/^TS_[A-Za-z0-9_]*=/d' "$TAILSCALED_DEFAULTS_FILE"
 
   printf '%s\n' "$TAILSCALED_ENVIRONMENT_MARKER" >> "$TAILSCALED_DEFAULTS_FILE"
-  grep '^TS_[A-Za-z0-9_]*=' "$_environment_file" >> "$TAILSCALED_DEFAULTS_FILE" || true
+  if [ -f "$_environment_file" ]; then
+    grep '^TS_[A-Za-z0-9_]*=' "$_environment_file" >> "$TAILSCALED_DEFAULTS_FILE" || true
+  fi
 }
 
 tailscale_install() {
@@ -137,7 +139,7 @@ tailscale_install() {
   echo "Configuring Tailscaled startup flags..."
   sed -i "s@FLAGS=\"[^\"]*\"@FLAGS=\"--state /data/tailscale/tailscaled.state ${TAILSCALED_FLAGS}\"@" "$TAILSCALED_DEFAULTS_FILE" || {
       echo "Failed to configure Tailscaled startup flags"
-      echo "Check that the file $TAILSCALED_DEFAULTS_FILE exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
+      echo "Check that the file $TAILSCALED_DEFAULTS_FILE exists and contains the line FLAGS=\"--state /data/tailscale/tailscaled.state ${TAILSCALED_FLAGS}\"."
       exit 1
   }
 

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -4,6 +4,8 @@ set -e
 PACKAGE_ROOT="${PACKAGE_ROOT:-"$(dirname -- "$(readlink -f -- "$0";)")"}"
 export TAILSCALE_ROOT="${TAILSCALE_ROOT:-/data/tailscale}"
 SYSTEMD_UNIT_DIR="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
+TAILSCALED_DEFAULTS_FILE="${TAILSCALED_DEFAULTS_FILE:-/etc/default/tailscaled}"
+TAILSCALED_ENVIRONMENT_MARKER="# tailscale-unifi managed environment"
 
 tailscale_status() {
   if ! command -v tailscale >/dev/null 2>&1; then
@@ -84,6 +86,16 @@ ensure_systemd_units() {
   systemctl enable --now tailscale-install.timer
 }
 
+sync_tailscaled_environment() {
+  _environment_file="${TAILSCALE_ROOT}/tailscale-env"
+
+  sed -i "/^${TAILSCALED_ENVIRONMENT_MARKER}$/,\$d" "$TAILSCALED_DEFAULTS_FILE"
+  sed -i '/^TS_[A-Za-z0-9_]*=/d' "$TAILSCALED_DEFAULTS_FILE"
+
+  printf '%s\n' "$TAILSCALED_ENVIRONMENT_MARKER" >> "$TAILSCALED_DEFAULTS_FILE"
+  grep '^TS_[A-Za-z0-9_]*=' "$_environment_file" >> "$TAILSCALED_DEFAULTS_FILE" || true
+}
+
 tailscale_install() {
   # shellcheck source=tests/os-release
   . "${OS_RELEASE_FILE:-/etc/os-release}"
@@ -116,18 +128,21 @@ tailscale_install() {
   fi
 
   echo "Configuring Tailscale port..."
-  sed -i "s/PORT=\"[^\"]*\"/PORT=\"${PORT:-41641}\"/" /etc/default/tailscaled || {
+  sed -i "s/PORT=\"[^\"]*\"/PORT=\"${PORT:-41641}\"/" "$TAILSCALED_DEFAULTS_FILE" || {
       echo "Failed to configure Tailscale port"
-      echo "Check that the file /etc/default/tailscaled exists and contains the line PORT=\"${PORT:-41641}\"."
+      echo "Check that the file $TAILSCALED_DEFAULTS_FILE exists and contains the line PORT=\"${PORT:-41641}\"."
       exit 1
   }
 
   echo "Configuring Tailscaled startup flags..."
-  sed -i "s@FLAGS=\"[^\"]*\"@FLAGS=\"--state /data/tailscale/tailscaled.state ${TAILSCALED_FLAGS}\"@" /etc/default/tailscaled || {
+  sed -i "s@FLAGS=\"[^\"]*\"@FLAGS=\"--state /data/tailscale/tailscaled.state ${TAILSCALED_FLAGS}\"@" "$TAILSCALED_DEFAULTS_FILE" || {
       echo "Failed to configure Tailscaled startup flags"
-      echo "Check that the file /etc/default/tailscaled exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
+      echo "Check that the file $TAILSCALED_DEFAULTS_FILE exists and contains the line FLAGS=\"--state /data/tailscale/tailscale.state ${TAILSCALED_FLAGS}\"."
       exit 1
   }
+
+  echo "Configuring Tailscaled environment..."
+  sync_tailscaled_environment
 
   echo "Restarting Tailscale daemon to detect new configuration..."
   systemctl restart tailscaled.service || {

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -4,6 +4,7 @@ set -e
 ROOT="$(dirname "$(dirname "$0")")"
 WORKDIR="$(mktemp -d || exit 1)"
 trap 'rm -rf ${WORKDIR}' EXIT
+REAL_SED="$(command -v sed)"
 
 # shellcheck source=tests/helpers.sh
 . "${ROOT}/tests/helpers.sh"
@@ -13,6 +14,7 @@ PACKAGE_ROOT="$(cd "${ROOT}/package" && pwd)"
 export PACKAGE_ROOT
 export TAILSCALE_ROOT="${WORKDIR}"
 export TAILSCALED_SOCK="${WORKDIR}/tailscaled.sock"
+export TAILSCALED_DEFAULTS_FILE="${WORKDIR}/tailscaled.defaults"
 export SYSTEMD_UNIT_DIR="${WORKDIR}/systemd"
 export OS_VERSION="v2"
 
@@ -22,8 +24,13 @@ export PATH="${WORKDIR}:${PATH}"
 mock "${WORKDIR}/apt-key" "--## apt-key mock: \$* ##--"
 mock "${WORKDIR}/tee" "--## tee mock: \$* ##--"
 mock "${WORKDIR}/apt" "--## apt mock: \$* ##--"
-mock "${WORKDIR}/sed" "--## sed mock: \$* ##--"
 mock "${WORKDIR}/ubnt-device-info" "2.0.0"
+cat > "${WORKDIR}/sed" <<EOF
+#!/usr/bin/env bash
+echo "\${@}" >> "${WORKDIR}/sed.args"
+exec "${REAL_SED}" "\$@"
+EOF
+chmod +x "${WORKDIR}/sed"
 # NB: `ln` is deliberately NOT mocked.  manage.sh no longer creates symlinks
 # (it copies unit files), so the only `ln` calls are the symlink fixtures the
 # tests below set up — those must use the real `ln` to be meaningful.
@@ -65,6 +72,13 @@ cp "${ROOT}/tests/os-release" "${WORKDIR}/os-release"
 export OS_RELEASE_FILE="${WORKDIR}/os-release"
 
 cp "${PACKAGE_ROOT}/tailscale-env" "${WORKDIR}/tailscale-env"
+printf '%s\n' 'TS_TUN_DISABLE_TCP_GRO=1' >> "${WORKDIR}/tailscale-env"
+cat > "${TAILSCALED_DEFAULTS_FILE}" <<EOF
+PORT="12345"
+FLAGS=""
+TS_TUN_DISABLE_TCP_GRO=0
+UNRELATED_SETTING="preserved"
+EOF
 
 # ── fresh install (clean SYSTEMD_UNIT_DIR) ────────────────────────────────────
 "${ROOT}/package/manage.sh" install; assert "Tailscale installer should run successfully"
@@ -76,6 +90,10 @@ sed_args=$(cat "${WORKDIR}/sed.args")
 assert_contains "$apt_first" "update" "The apt command should be called to update the package list"
 assert_contains "$apt_second" "install -y tailscale" "The apt command should be called with the command to install tailscale file"
 assert_contains "$sed_args" "--state /data/tailscale" "The defaults should be updated with state directory"
+assert_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "TS_TUN_DISABLE_TCP_GRO=1" "TS_ variables should be copied to the tailscaled defaults"
+assert_not_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "TS_TUN_DISABLE_TCP_GRO=0" "Existing TS_ variable values should be replaced"
+assert_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "UNRELATED_SETTING=\"preserved\"" "Unrelated tailscaled defaults should be preserved"
+assert_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "# tailscale-unifi managed environment" "Managed environment should be separated from the original defaults"
 [[ -f "${WORKDIR}/tailscaled.restarted" ]]; assert "tailscaled should have been restarted"
 [[ -f "${WORKDIR}/tailscaled.service.enabled" ]]; assert "tailscaled unit should be enabled"
 [[ -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "systemctl should have been reloaded"
@@ -97,6 +115,16 @@ ln -sf "${PACKAGE_ROOT}/tailscale-install.timer" \
 
 "${ROOT}/package/manage.sh" install; assert "Upgrade from symlink state should succeed without 'same file' error"
 
+[[ "$(grep -c '^TS_TUN_DISABLE_TCP_GRO=' "${TAILSCALED_DEFAULTS_FILE}")" -eq 1 ]]; assert "Repeated installs should not duplicate TS_ variables in the tailscaled defaults"
+[[ "$(grep -c '^# tailscale-unifi managed environment$' "${TAILSCALED_DEFAULTS_FILE}")" -eq 1 ]]; assert "Repeated installs should not duplicate the managed environment section"
+
+sed -i '/^TS_TUN_DISABLE_TCP_GRO=/d' "${WORKDIR}/tailscale-env"
+"${ROOT}/package/manage.sh" install; assert "Install should succeed after removing a TS_ variable"
+
+assert_not_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "TS_TUN_DISABLE_TCP_GRO=" "Removed TS_ variables should be removed from the tailscaled defaults"
+assert_contains "$(cat "${TAILSCALED_DEFAULTS_FILE}")" "UNRELATED_SETTING=\"preserved\"" "Removing a TS_ variable should preserve the original defaults"
+[[ "$(grep -c '^# tailscale-unifi managed environment$' "${TAILSCALED_DEFAULTS_FILE}")" -eq 1 ]]; assert "The empty managed environment section should remain singular"
+
 # After the fix the destination must be a regular file, not a symlink.
 # If rm -f silently failed and cp wrote through the symlink instead, the
 # destination would still appear as a file — only -L distinguishes the two.
@@ -112,7 +140,13 @@ mock "${WORKDIR}/curl" ""
 mock "${WORKDIR}/jq" ""
 reset_mock "${WORKDIR}/apt"
 
-update_out=$("${ROOT}/package/manage.sh" update 2>&1) || true
+NO_TAILSCALE_BIN="${WORKDIR}/no-tailscale-bin"
+mkdir -p "$NO_TAILSCALE_BIN"
+for command_name in bash cmp cp dirname grep readlink rm touch; do
+    ln -s "$(command -v "$command_name")" "$NO_TAILSCALE_BIN/$command_name"
+done
+
+update_out=$(PATH="${WORKDIR}:${NO_TAILSCALE_BIN}" "${ROOT}/package/manage.sh" update 2>&1) || true
 assert_not_contains "$update_out" "tailscale: not found" "update with tailscale absent does not emit 'tailscale: not found'"
 assert_contains "$(cat "${WORKDIR}/apt.args")" "install -y tailscale" "update with tailscale absent triggers an install"
 


### PR DESCRIPTION
## Summary

- sync `TS_*` settings from `tailscale-env` into a managed section of `/etc/default/tailscaled`
- remove stale managed settings when entries are deleted
- preserve the original tailscaled defaults while replacing the managed section idempotently
- document the configuration workflow

Relates to #205.

## Validation

- `./tests/install.test.sh`
- `shellcheck --severity=warning package/manage.sh tests/install.test.sh`

The full test suite also reaches an unrelated host-dependent failure in `status.test.sh` when a real `tailscale` binary is installed on the test host.