### PR TITLE
Fix/persistent unifi cert renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,19 +217,20 @@ Tailscale can generate valid HTTPS certificates for your device using Let’s En
 # Generate a certificate
 /data/tailscale/manage.sh cert generate
 
-# Renew an existing certificate before it expires
+# Renew an existing certificate before it expires. If it is the active UniFi
+# certificate, the same UniFi certificate record is updated automatically.
 /data/tailscale/manage.sh cert renew
 
 # Install certificate into UniFi OS
 /data/tailscale/manage.sh cert install-unifi
 
-# Restart UniFi Core to apply
+# Restart UniFi Core after the initial installation
 systemctl restart unifi-core
 ```
 
 Certificates expire after 90 days. The hostname is automatically determined from your Tailscale configuration.
 
-On UniFi OS, a systemd timer is automatically installed when you generate your first certificate. This timer runs weekly to check and renew certificates before they expire.
+On UniFi OS, a systemd timer is automatically installed when you generate your first certificate. This timer runs weekly to check and renew certificates before they expire. If the active UniFi certificate still matches the previously installed Tailscale certificate, renewal updates its files and database record and restarts UniFi Core. A different active certificate is left untouched.
 
 [tailscale-pr10828]: https://github.com/tailscale/tailscale/pull/10828
 [tailscale-pr14452]: https://github.com/tailscale/tailscale/pull/14452

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -6,6 +6,7 @@ export TAILSCALE_ROOT="${TAILSCALE_ROOT:-/data/tailscale}"
 SYSTEMD_UNIT_DIR="${SYSTEMD_UNIT_DIR:-/etc/systemd/system}"
 TAILSCALED_DEFAULTS_FILE="${TAILSCALED_DEFAULTS_FILE:-/etc/default/tailscaled}"
 TAILSCALED_ENVIRONMENT_MARKER="# tailscale-unifi managed environment"
+UNIFI_CONFIG_DIR="${UNIFI_CONFIG_DIR:-/data/unifi-core/config}"
 
 tailscale_status() {
   if ! command -v tailscale >/dev/null 2>&1; then
@@ -84,6 +85,25 @@ ensure_systemd_units() {
   systemctl daemon-reload
   systemctl enable tailscale-install.service
   systemctl enable --now tailscale-install.timer
+}
+
+ensure_cert_renewal_units() {
+  echo "Installing certificate auto-renewal timer..."
+  install_systemd_unit tailscale-cert-renewal.service
+  install_systemd_unit tailscale-cert-renewal.timer
+  systemctl daemon-reload
+  systemctl enable tailscale-cert-renewal.timer
+  systemctl start tailscale-cert-renewal.timer
+  echo "Certificate will be automatically renewed weekly"
+}
+
+repair_cert_renewal_units_if_configured() {
+  for _cert_file in "${TAILSCALE_ROOT}"/certs/*.crt; do
+    [ -f "$_cert_file" ] || continue
+    [ -f "${_cert_file%.crt}.key" ] || continue
+    ensure_cert_renewal_units
+    return 0
+  done
 }
 
 sync_tailscaled_environment() {
@@ -241,13 +261,7 @@ tailscale_cert_generate() {
       # Install (or repair) the cert-renewal units.  install_systemd_unit removes
       # any pre-existing symlink before copying (see its comment for why).
       if [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.service" ] && [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" ]; then
-          echo "Installing certificate auto-renewal timer..."
-          install_systemd_unit tailscale-cert-renewal.service
-          install_systemd_unit tailscale-cert-renewal.timer
-          systemctl daemon-reload
-          systemctl enable tailscale-cert-renewal.timer
-          systemctl start tailscale-cert-renewal.timer
-          echo "Certificate will be automatically renewed weekly"
+          ensure_cert_renewal_units
       fi
   else
       echo "Failed to generate certificate. Ensure:"
@@ -258,10 +272,74 @@ tailscale_cert_generate() {
   fi
 }
 
+tailscale_cert_installed_unifi_uuid() {
+  _source_cert="$1"
+  _source_key="$2"
+  _settings_file="${UNIFI_CONFIG_DIR}/settings.yaml"
+
+  [ -f "$_settings_file" ] || return 1
+
+  _cert_uuid=$(sed -n 's/^[[:space:]]*activeCertId:[[:space:]]*\([0-9A-Fa-f-]*\).*$/\1/p' "$_settings_file" | head -n 1)
+  if ! printf '%s\n' "$_cert_uuid" | grep -Eq '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'; then
+    return 1
+  fi
+
+  [ -f "${UNIFI_CONFIG_DIR}/${_cert_uuid}.crt" ] || return 1
+  [ -f "${UNIFI_CONFIG_DIR}/${_cert_uuid}.key" ] || return 1
+  cmp -s "$_source_cert" "${UNIFI_CONFIG_DIR}/${_cert_uuid}.crt" || return 1
+  cmp -s "$_source_key" "${UNIFI_CONFIG_DIR}/${_cert_uuid}.key" || return 1
+
+  printf '%s\n' "$_cert_uuid"
+}
+
+tailscale_cert_update_unifi() {
+  _cert_uuid="$1"
+  _source_cert="$2"
+  _source_key="$3"
+  _target_cert="${UNIFI_CONFIG_DIR}/${_cert_uuid}.crt"
+  _target_key="${UNIFI_CONFIG_DIR}/${_cert_uuid}.key"
+  _target_cert_backup="${_target_cert}.tailscale-unifi.bak"
+  _target_key_backup="${_target_key}.tailscale-unifi.bak"
+  _db_helper="${TAILSCALE_ROOT}/helpers/cert-db-register.sh"
+
+  if [ ! -f "$_db_helper" ]; then
+    echo "Cannot update UniFi certificate: database registration script not found"
+    return 1
+  fi
+
+  cp "$_target_cert" "$_target_cert_backup"
+  cp "$_target_key" "$_target_key_backup"
+  cp "$_source_cert" "$_target_cert"
+  cp "$_source_key" "$_target_key"
+  chmod 644 "$_target_cert"
+  chmod 600 "$_target_key"
+
+  if ! sh "$_db_helper" "$_cert_uuid" "$_target_cert" "$_target_key" "$TAILSCALE_HOSTNAME"; then
+    mv "$_target_cert_backup" "$_target_cert"
+    mv "$_target_key_backup" "$_target_key"
+    echo "Failed to update certificate in UniFi database"
+    return 1
+  fi
+
+  if ! systemctl restart unifi-core; then
+    mv "$_target_cert_backup" "$_target_cert"
+    mv "$_target_key_backup" "$_target_key"
+    sh "$_db_helper" "$_cert_uuid" "$_target_cert" "$_target_key" "$TAILSCALE_HOSTNAME" || \
+      echo "Warning: failed to restore the previous UniFi database record"
+    echo "Failed to restart UniFi Core; restored the previous certificate"
+    return 1
+  fi
+
+  rm -f "$_target_cert_backup" "$_target_key_backup"
+  echo "UniFi OS certificate updated with ID: $_cert_uuid"
+}
+
 tailscale_cert_renew() {
   cert_dir="${TAILSCALE_ROOT}/certs"
+  cert_file="$cert_dir/$TAILSCALE_HOSTNAME.crt"
+  key_file="$cert_dir/$TAILSCALE_HOSTNAME.key"
 
-  if [ ! -f "$cert_dir/$TAILSCALE_HOSTNAME.crt" ] || [ ! -f "$cert_dir/$TAILSCALE_HOSTNAME.key" ]; then
+  if [ ! -f "$cert_file" ] || [ ! -f "$key_file" ]; then
       echo "Certificate not found for $TAILSCALE_HOSTNAME"
       echo "Use '$0 cert generate' to create a new certificate"
       exit 1
@@ -270,18 +348,34 @@ tailscale_cert_renew() {
   echo "Renewing certificate for $TAILSCALE_HOSTNAME..."
 
   # Backup existing certificates
-  cp "$cert_dir/$TAILSCALE_HOSTNAME.crt" "$cert_dir/$TAILSCALE_HOSTNAME.crt.bak"
-  cp "$cert_dir/$TAILSCALE_HOSTNAME.key" "$cert_dir/$TAILSCALE_HOSTNAME.key.bak"
+  cp "$cert_file" "$cert_file.bak"
+  cp "$key_file" "$key_file.bak"
 
-  if tailscale cert --cert-file "$cert_dir/$TAILSCALE_HOSTNAME.crt" --key-file "$cert_dir/$TAILSCALE_HOSTNAME.key" "$TAILSCALE_HOSTNAME"; then
-      chmod 644 "$cert_dir/$TAILSCALE_HOSTNAME.crt"
-      chmod 600 "$cert_dir/$TAILSCALE_HOSTNAME.key"
-      rm -f "$cert_dir/$TAILSCALE_HOSTNAME.crt.bak" "$cert_dir/$TAILSCALE_HOSTNAME.key.bak"
+  installed_unifi_uuid=""
+  if installed_unifi_uuid=$(tailscale_cert_installed_unifi_uuid "$cert_file.bak" "$key_file.bak"); then
+    echo "Found matching installed UniFi certificate with ID: $installed_unifi_uuid"
+  fi
+
+  if tailscale cert --cert-file "$cert_file" --key-file "$key_file" "$TAILSCALE_HOSTNAME"; then
+      chmod 644 "$cert_file"
+      chmod 600 "$key_file"
+
+      if [ -n "$installed_unifi_uuid" ] && \
+         { ! cmp -s "$cert_file.bak" "$cert_file" || ! cmp -s "$key_file.bak" "$key_file"; }; then
+          if ! tailscale_cert_update_unifi "$installed_unifi_uuid" "$cert_file" "$key_file"; then
+              mv "$cert_file.bak" "$cert_file"
+              mv "$key_file.bak" "$key_file"
+              echo "Failed to update the installed UniFi certificate; restored the previous Tailscale certificate"
+              exit 1
+          fi
+      fi
+
+      rm -f "$cert_file.bak" "$key_file.bak"
       echo "Certificate renewed successfully"
   else
       # Restore backups on failure
-      mv "$cert_dir/$TAILSCALE_HOSTNAME.crt.bak" "$cert_dir/$TAILSCALE_HOSTNAME.crt"
-      mv "$cert_dir/$TAILSCALE_HOSTNAME.key.bak" "$cert_dir/$TAILSCALE_HOSTNAME.key"
+      mv "$cert_file.bak" "$cert_file"
+      mv "$key_file.bak" "$key_file"
       echo "Failed to renew certificate"
       exit 1
   fi
@@ -321,24 +415,24 @@ tailscale_cert_install_unifi() {
   echo "Installing certificate for UniFi controller..."
 
   # Install for UniFi OS (nginx)
-  if [ -d "/data/unifi-core/config" ]; then
+  if [ -d "$UNIFI_CONFIG_DIR" ]; then
       echo "Installing certificate for UniFi OS web interface..."
 
       # Generate a UUID for the certificate
       cert_uuid=$(cat /proc/sys/kernel/random/uuid)
 
       # Copy certificates with UUID names
-      cp "$cert_dir/$TAILSCALE_HOSTNAME.crt" "/data/unifi-core/config/$cert_uuid.crt"
-      cp "$cert_dir/$TAILSCALE_HOSTNAME.key" "/data/unifi-core/config/$cert_uuid.key"
+      cp "$cert_dir/$TAILSCALE_HOSTNAME.crt" "$UNIFI_CONFIG_DIR/$cert_uuid.crt"
+      cp "$cert_dir/$TAILSCALE_HOSTNAME.key" "$UNIFI_CONFIG_DIR/$cert_uuid.key"
 
       # Set proper permissions
-      chmod 644 "/data/unifi-core/config/$cert_uuid.crt"
-      chmod 600 "/data/unifi-core/config/$cert_uuid.key"
+      chmod 644 "$UNIFI_CONFIG_DIR/$cert_uuid.crt"
+      chmod 600 "$UNIFI_CONFIG_DIR/$cert_uuid.key"
 
       # Register certificate in PostgreSQL database for persistence
       if [ -f "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" ]; then
           echo "Registering certificate in database..."
-          if ! sh "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" "$cert_uuid" "/data/unifi-core/config/$cert_uuid.crt" "/data/unifi-core/config/$cert_uuid.key" "$TAILSCALE_HOSTNAME"; then
+          if ! sh "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" "$cert_uuid" "$UNIFI_CONFIG_DIR/$cert_uuid.crt" "$UNIFI_CONFIG_DIR/$cert_uuid.key" "$TAILSCALE_HOSTNAME"; then
               echo "Failed to register certificate in UniFi database"
               exit 1
           fi
@@ -347,18 +441,18 @@ tailscale_cert_install_unifi() {
       fi
 
       # Update nginx configuration
-      cat > /data/unifi-core/config/http/local-certs.conf <<EOF
-ssl_certificate     /data/unifi-core/config/$cert_uuid.crt;
-ssl_certificate_key /data/unifi-core/config/$cert_uuid.key;
+      cat > "$UNIFI_CONFIG_DIR/http/local-certs.conf" <<EOF
+ssl_certificate     $UNIFI_CONFIG_DIR/$cert_uuid.crt;
+ssl_certificate_key $UNIFI_CONFIG_DIR/$cert_uuid.key;
 EOF
 
       # Update settings.yaml to activate the certificate
-      if grep -q "activeCertId:" /data/unifi-core/config/settings.yaml 2>/dev/null; then
+      if grep -q "activeCertId:" "$UNIFI_CONFIG_DIR/settings.yaml" 2>/dev/null; then
           # Update existing activeCertId
-          sed -i "s/activeCertId: .*/activeCertId: $cert_uuid/" /data/unifi-core/config/settings.yaml
+          sed -i "s/activeCertId: .*/activeCertId: $cert_uuid/" "$UNIFI_CONFIG_DIR/settings.yaml"
       else
           # Add activeCertId if it doesn't exist
-          echo "activeCertId: $cert_uuid" >> /data/unifi-core/config/settings.yaml
+          echo "activeCertId: $cert_uuid" >> "$UNIFI_CONFIG_DIR/settings.yaml"
       fi
 
       echo "UniFi OS certificate installed with ID: $cert_uuid"
@@ -498,6 +592,7 @@ case $1 in
     # first means the units are healthy for the next boot even if the steps
     # below fail.
     ensure_systemd_units
+    repair_cert_renewal_units_if_configured
 
     if ! command -v tailscale >/dev/null 2>&1; then
       tailscale_install

--- a/package/manage.sh
+++ b/package/manage.sh
@@ -88,6 +88,9 @@ ensure_systemd_units() {
 }
 
 ensure_cert_renewal_units() {
+  [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.service" ] || return 0
+  [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" ] || return 0
+
   echo "Installing certificate auto-renewal timer..."
   install_systemd_unit tailscale-cert-renewal.service
   install_systemd_unit tailscale-cert-renewal.timer
@@ -260,9 +263,7 @@ tailscale_cert_generate() {
 
       # Install (or repair) the cert-renewal units.  install_systemd_unit removes
       # any pre-existing symlink before copying (see its comment for why).
-      if [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.service" ] && [ -f "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" ]; then
-          ensure_cert_renewal_units
-      fi
+      ensure_cert_renewal_units
   else
       echo "Failed to generate certificate. Ensure:"
       echo "  - Your Tailscale session is valid and you are logged in"
@@ -292,46 +293,32 @@ tailscale_cert_installed_unifi_uuid() {
   printf '%s\n' "$_cert_uuid"
 }
 
-tailscale_cert_update_unifi() {
+tailscale_cert_write_unifi() {
   _cert_uuid="$1"
   _source_cert="$2"
   _source_key="$3"
   _target_cert="${UNIFI_CONFIG_DIR}/${_cert_uuid}.crt"
   _target_key="${UNIFI_CONFIG_DIR}/${_cert_uuid}.key"
-  _target_cert_backup="${_target_cert}.tailscale-unifi.bak"
-  _target_key_backup="${_target_key}.tailscale-unifi.bak"
   _db_helper="${TAILSCALE_ROOT}/helpers/cert-db-register.sh"
 
   if [ ! -f "$_db_helper" ]; then
-    echo "Cannot update UniFi certificate: database registration script not found"
+    echo "Cannot install UniFi certificate: database registration script not found"
     return 1
   fi
 
-  cp "$_target_cert" "$_target_cert_backup"
-  cp "$_target_key" "$_target_key_backup"
-  cp "$_source_cert" "$_target_cert"
-  cp "$_source_key" "$_target_key"
-  chmod 644 "$_target_cert"
-  chmod 600 "$_target_key"
+  if ! cp "$_source_cert" "$_target_cert" || \
+     ! cp "$_source_key" "$_target_key" || \
+     ! chmod 644 "$_target_cert" || \
+     ! chmod 600 "$_target_key"; then
+    echo "Failed to copy certificate into UniFi configuration"
+    return 1
+  fi
 
+  echo "Registering certificate in database..."
   if ! sh "$_db_helper" "$_cert_uuid" "$_target_cert" "$_target_key" "$TAILSCALE_HOSTNAME"; then
-    mv "$_target_cert_backup" "$_target_cert"
-    mv "$_target_key_backup" "$_target_key"
-    echo "Failed to update certificate in UniFi database"
+    echo "Failed to register certificate in UniFi database"
     return 1
   fi
-
-  if ! systemctl restart unifi-core; then
-    mv "$_target_cert_backup" "$_target_cert"
-    mv "$_target_key_backup" "$_target_key"
-    sh "$_db_helper" "$_cert_uuid" "$_target_cert" "$_target_key" "$TAILSCALE_HOSTNAME" || \
-      echo "Warning: failed to restore the previous UniFi database record"
-    echo "Failed to restart UniFi Core; restored the previous certificate"
-    return 1
-  fi
-
-  rm -f "$_target_cert_backup" "$_target_key_backup"
-  echo "UniFi OS certificate updated with ID: $_cert_uuid"
 }
 
 tailscale_cert_renew() {
@@ -362,10 +349,19 @@ tailscale_cert_renew() {
 
       if [ -n "$installed_unifi_uuid" ] && \
          { ! cmp -s "$cert_file.bak" "$cert_file" || ! cmp -s "$key_file.bak" "$key_file"; }; then
-          if ! tailscale_cert_update_unifi "$installed_unifi_uuid" "$cert_file" "$key_file"; then
+          if ! tailscale_cert_write_unifi "$installed_unifi_uuid" "$cert_file" "$key_file"; then
+              tailscale_cert_write_unifi "$installed_unifi_uuid" "$cert_file.bak" "$key_file.bak" || \
+                echo "Warning: failed to restore the previous UniFi certificate"
               mv "$cert_file.bak" "$cert_file"
               mv "$key_file.bak" "$key_file"
               echo "Failed to update the installed UniFi certificate; restored the previous Tailscale certificate"
+              exit 1
+          fi
+
+          rm -f "$cert_file.bak" "$key_file.bak"
+          echo "UniFi OS certificate updated with ID: $installed_unifi_uuid"
+          if ! systemctl restart unifi-core; then
+              echo "UniFi certificate was updated, but UniFi Core failed to restart"
               exit 1
           fi
       fi
@@ -421,23 +417,8 @@ tailscale_cert_install_unifi() {
       # Generate a UUID for the certificate
       cert_uuid=$(cat /proc/sys/kernel/random/uuid)
 
-      # Copy certificates with UUID names
-      cp "$cert_dir/$TAILSCALE_HOSTNAME.crt" "$UNIFI_CONFIG_DIR/$cert_uuid.crt"
-      cp "$cert_dir/$TAILSCALE_HOSTNAME.key" "$UNIFI_CONFIG_DIR/$cert_uuid.key"
-
-      # Set proper permissions
-      chmod 644 "$UNIFI_CONFIG_DIR/$cert_uuid.crt"
-      chmod 600 "$UNIFI_CONFIG_DIR/$cert_uuid.key"
-
-      # Register certificate in PostgreSQL database for persistence
-      if [ -f "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" ]; then
-          echo "Registering certificate in database..."
-          if ! sh "${TAILSCALE_ROOT}/helpers/cert-db-register.sh" "$cert_uuid" "$UNIFI_CONFIG_DIR/$cert_uuid.crt" "$UNIFI_CONFIG_DIR/$cert_uuid.key" "$TAILSCALE_HOSTNAME"; then
-              echo "Failed to register certificate in UniFi database"
-              exit 1
-          fi
-      else
-          echo "Warning: Database registration script not found. Certificate may not persist across restarts."
+      if ! tailscale_cert_write_unifi "$cert_uuid" "$cert_dir/$TAILSCALE_HOSTNAME.crt" "$cert_dir/$TAILSCALE_HOSTNAME.key"; then
+          exit 1
       fi
 
       # Update nginx configuration

--- a/tests/cert.test.sh
+++ b/tests/cert.test.sh
@@ -43,6 +43,9 @@ case "\$1" in
         ;;
     "restart")
         echo "--## systemctl restart \$2 ##--"
+        if [ -f "${WORKDIR}/fail-\$2-restart" ]; then
+            exit 1
+        fi
         touch "${WORKDIR}/\$2.restarted"
         ;;
     *)
@@ -222,6 +225,32 @@ test_cert_renew_rolls_back_when_unifi_update_fails() {
     rm -rf "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
 }
 
+test_cert_renew_keeps_updated_state_when_unifi_restart_fails() {
+    cert_uuid="12345678-1234-1234-1234-123456789012"
+    unifi_config_dir="${WORKDIR}/unifi-core/config"
+
+    mkdir -p "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+    touch "$TAILSCALED_SOCK" "$WORKDIR/fail-unifi-core-restart"
+    echo "OLD CERT" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt"
+    echo "OLD KEY" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.key"
+    echo "OLD CERT" > "$unifi_config_dir/$cert_uuid.crt"
+    echo "OLD KEY" > "$unifi_config_dir/$cert_uuid.key"
+    echo "activeCertId: $cert_uuid" > "$unifi_config_dir/settings.yaml"
+    mock "$TAILSCALE_ROOT/helpers/cert-db-register.sh"
+
+    output=$(UNIFI_CONFIG_DIR="$unifi_config_dir" "$MANAGE_SH" cert renew 2>&1) || true
+
+    assert_contains "$output" "UniFi certificate was updated, but UniFi Core failed to restart" \
+        "Renewal reports when the updated certificate could not be activated"
+    assert_eq "CERTIFICATE" "$(cat "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt")" \
+        "Renewed Tailscale certificate remains after a UniFi restart failure"
+    assert_eq "CERTIFICATE" "$(cat "$unifi_config_dir/$cert_uuid.crt")" \
+        "Updated UniFi certificate remains after a restart failure"
+
+    rm -rf "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+    rm -f "$WORKDIR/fail-unifi-core-restart"
+}
+
 # Test certificate info
 test_cert_info() {
     mkdir -p "$TAILSCALE_ROOT/certs"
@@ -296,6 +325,7 @@ test_cert_renew
 test_cert_renew_updates_installed_unifi_cert
 test_cert_renew_does_not_replace_unrelated_unifi_cert
 test_cert_renew_rolls_back_when_unifi_update_fails
+test_cert_renew_keeps_updated_state_when_unifi_restart_fails
 test_cert_info
 test_cert_not_running
 test_cert_help

--- a/tests/cert.test.sh
+++ b/tests/cert.test.sh
@@ -41,6 +41,10 @@ case "\$1" in
         echo "--## systemctl start \$2 ##--"
         touch "${WORKDIR}/\$2.started"
         ;;
+    "restart")
+        echo "--## systemctl restart \$2 ##--"
+        touch "${WORKDIR}/\$2.restarted"
+        ;;
     *)
         echo "Unexpected command: \${1}"
         exit 1
@@ -137,6 +141,87 @@ test_cert_renew() {
     rm -rf "$TAILSCALE_ROOT/certs"
 }
 
+test_cert_renew_updates_installed_unifi_cert() {
+    cert_uuid="12345678-1234-1234-1234-123456789012"
+    unifi_config_dir="${WORKDIR}/unifi-core/config"
+
+    mkdir -p "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+    touch "$TAILSCALED_SOCK"
+    echo "OLD CERT" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt"
+    echo "OLD KEY" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.key"
+    echo "OLD CERT" > "$unifi_config_dir/$cert_uuid.crt"
+    echo "OLD KEY" > "$unifi_config_dir/$cert_uuid.key"
+    echo "activeCertId: $cert_uuid" > "$unifi_config_dir/settings.yaml"
+    mock "$TAILSCALE_ROOT/helpers/cert-db-register.sh"
+
+    output=$(UNIFI_CONFIG_DIR="$unifi_config_dir" "$MANAGE_SH" cert renew 2>&1)
+
+    assert_contains "$output" "UniFi OS certificate updated" \
+        "Renewal updates the installed UniFi certificate"
+    assert_eq "CERTIFICATE" "$(cat "$unifi_config_dir/$cert_uuid.crt")" \
+        "Installed UniFi certificate contains the renewed certificate"
+    assert_eq "PRIVATE KEY" "$(cat "$unifi_config_dir/$cert_uuid.key")" \
+        "Installed UniFi key contains the renewed private key"
+    assert_contains "$(cat "$TAILSCALE_ROOT/helpers/cert-db-register.sh.args")" "$cert_uuid" \
+        "Renewal updates the existing UniFi database record"
+    assert_file_exists "$WORKDIR/unifi-core.restarted" \
+        "Renewal restarts UniFi Core after installing a changed certificate"
+
+    rm -rf "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+    rm -f "$WORKDIR/unifi-core.restarted"
+}
+
+test_cert_renew_does_not_replace_unrelated_unifi_cert() {
+    cert_uuid="12345678-1234-1234-1234-123456789012"
+    unifi_config_dir="${WORKDIR}/unifi-core/config"
+
+    mkdir -p "$TAILSCALE_ROOT/certs" "$unifi_config_dir"
+    touch "$TAILSCALED_SOCK"
+    echo "OLD CERT" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt"
+    echo "OLD KEY" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.key"
+    echo "UNRELATED CERT" > "$unifi_config_dir/$cert_uuid.crt"
+    echo "UNRELATED KEY" > "$unifi_config_dir/$cert_uuid.key"
+    echo "activeCertId: $cert_uuid" > "$unifi_config_dir/settings.yaml"
+
+    output=$(UNIFI_CONFIG_DIR="$unifi_config_dir" "$MANAGE_SH" cert renew 2>&1)
+
+    assert_not_contains "$output" "UniFi OS certificate updated" \
+        "Renewal does not replace an unrelated active UniFi certificate"
+    assert_eq "UNRELATED CERT" "$(cat "$unifi_config_dir/$cert_uuid.crt")" \
+        "Unrelated active UniFi certificate remains unchanged"
+    [[ ! -f "$WORKDIR/unifi-core.restarted" ]]
+    assert "Renewal does not restart UniFi Core when its certificate is unrelated"
+
+    rm -rf "$TAILSCALE_ROOT/certs" "$unifi_config_dir"
+}
+
+test_cert_renew_rolls_back_when_unifi_update_fails() {
+    cert_uuid="12345678-1234-1234-1234-123456789012"
+    unifi_config_dir="${WORKDIR}/unifi-core/config"
+
+    mkdir -p "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+    touch "$TAILSCALED_SOCK"
+    echo "OLD CERT" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt"
+    echo "OLD KEY" > "$TAILSCALE_ROOT/certs/test-host.example.ts.net.key"
+    echo "OLD CERT" > "$unifi_config_dir/$cert_uuid.crt"
+    echo "OLD KEY" > "$unifi_config_dir/$cert_uuid.key"
+    echo "activeCertId: $cert_uuid" > "$unifi_config_dir/settings.yaml"
+    mock "$TAILSCALE_ROOT/helpers/cert-db-register.sh" "database unavailable" 1
+
+    output=$(UNIFI_CONFIG_DIR="$unifi_config_dir" "$MANAGE_SH" cert renew 2>&1) || true
+
+    assert_contains "$output" "restored the previous Tailscale certificate" \
+        "Renewal reports rollback when the UniFi database update fails"
+    assert_eq "OLD CERT" "$(cat "$TAILSCALE_ROOT/certs/test-host.example.ts.net.crt")" \
+        "Tailscale certificate is rolled back after a UniFi update failure"
+    assert_eq "OLD CERT" "$(cat "$unifi_config_dir/$cert_uuid.crt")" \
+        "Installed UniFi certificate is rolled back after a database failure"
+    [[ ! -f "$WORKDIR/unifi-core.restarted" ]]
+    assert "UniFi Core is not restarted after a database update failure"
+
+    rm -rf "$TAILSCALE_ROOT/certs" "$TAILSCALE_ROOT/helpers" "$unifi_config_dir"
+}
+
 # Test certificate info
 test_cert_info() {
     mkdir -p "$TAILSCALE_ROOT/certs"
@@ -208,6 +293,9 @@ test_cert_generate_upgrade_from_symlink() {
 # Run tests
 test_cert_generate
 test_cert_renew
+test_cert_renew_updates_installed_unifi_cert
+test_cert_renew_does_not_replace_unrelated_unifi_cert
+test_cert_renew_rolls_back_when_unifi_update_fails
 test_cert_info
 test_cert_not_running
 test_cert_help

--- a/tests/install.test.sh
+++ b/tests/install.test.sh
@@ -164,7 +164,7 @@ case "\$1" in
     "is-enabled")    exit 0 ;;
     "enable")        touch "${WORKDIR}/\$2.enabled" ;;
     "daemon-reload") touch "${WORKDIR}/systemctl.daemon-reload" ;;
-    "start")         touch "${WORKDIR}/tailscaled.started" ;;
+    "start")         touch "${WORKDIR}/\$2.started" ;;
     "restart")       touch "${WORKDIR}/tailscaled.restarted" ;;
     *) echo "Unexpected command: \${1}"; exit 1 ;;
 esac
@@ -182,12 +182,23 @@ mock "${WORKDIR}/sleep" ""
 printf '[Unit]\n# stale\n' > "${SYSTEMD_UNIT_DIR}/tailscale-install.service"
 ln -sf "${PACKAGE_ROOT}/tailscale-install.timer" \
        "${SYSTEMD_UNIT_DIR}/tailscale-install.timer"
+mkdir -p "${TAILSCALE_ROOT}/certs"
+printf '%s\n' 'CERTIFICATE' > "${TAILSCALE_ROOT}/certs/test-host.example.ts.net.crt"
+printf '%s\n' 'PRIVATE KEY' > "${TAILSCALE_ROOT}/certs/test-host.example.ts.net.key"
+ln -sf "${PACKAGE_ROOT}/tailscale-cert-renewal.service" \
+       "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.service"
+ln -sf "${PACKAGE_ROOT}/tailscale-cert-renewal.timer" \
+       "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.timer"
 rm -f "${WORKDIR}/systemctl.daemon-reload"
 
 "${ROOT}/package/manage.sh" on-boot; assert "on-boot succeeds when Tailscale is already installed"
 
 cmp -s "${PACKAGE_ROOT}/tailscale-install.service" "${SYSTEMD_UNIT_DIR}/tailscale-install.service"; assert "on-boot rewrites a stale tailscale-install.service to match the package while Tailscale is healthy"
 [[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-install.timer" ]]; assert "on-boot rewrites a symlinked tailscale-install.timer as a regular file while Tailscale is healthy"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.service" ]]; assert "on-boot rewrites a symlinked tailscale-cert-renewal.service as a regular file when certificates exist"
+[[ ! -L "${SYSTEMD_UNIT_DIR}/tailscale-cert-renewal.timer" ]]; assert "on-boot rewrites a symlinked tailscale-cert-renewal.timer as a regular file when certificates exist"
+[[ -f "${WORKDIR}/tailscale-cert-renewal.timer.enabled" ]]; assert "on-boot enables the certificate renewal timer when certificates exist"
+[[ -f "${WORKDIR}/tailscale-cert-renewal.timer.started" ]]; assert "on-boot starts the certificate renewal timer when certificates exist"
 [[ -f "${WORKDIR}/systemctl.daemon-reload" ]]; assert "on-boot runs daemon-reload after repairing stale units"
 
 # ── on-boot is safe to run repeatedly ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes automatic certificate renewal for certificates installed into UniFi OS.

The weekly renewal timer currently updates the certificate under `/data/tailscale/certs`, but leaves UniFi’s active UUID-named files and `user_certificates` database record unchanged. As a result, UniFi continues serving the old certificate until it expires.

This completes the automatic renewal path introduced in #117 and builds on the UniFi database registration restored in #172.

## What changed

- detect when UniFi’s active certificate and key match the previously installed Tailscale certificate
- update the existing UUID-named certificate files and database record after renewal
- restart `unifi-core` only when the certificate actually changes
- leave unrelated or manually configured UniFi certificates untouched
- restore the previous certificate if copying or database registration fails
- keep the consistent renewed state when only the `unifi-core` restart fails, while reporting that activation is pending
- share the UniFi certificate write/registration path between initial installation and renewal
- repair and enable certificate-renewal systemd units during boot when certificates already exist
- document the renewal behavior and add regression, rollback, restart-failure and custom-certificate coverage

## Why this approach

Reusing the active certificate UUID avoids accumulating abandoned certificate files and database rows on every renewal.

The renewal path only updates UniFi when its active certificate and key are byte-for-byte identical to the pre-renewal Tailscale files. This supports existing installations without adding migration state, while avoiding replacement of a custom certificate selected through UniFi.

As in #172, the database registration helper remains the source of truth for persistent UniFi certificate registration.

## Testing

- `tests/run.sh`
- `shellcheck -e SC2148 -x $(find . -type f -name '*.sh' -print)`

The full test suite and ShellCheck pass locally.

## Manual verification

The original failure was reproduced on a UDM Pro Max running UniFi OS 5: the Tailscale certificate renewed successfully, but UniFi continued serving the old UUID-backed certificate.

Renewing the certificate, updating the existing UUID files and database record, and restarting `unifi-core` caused the console to serve the renewed Let's Encrypt certificate. The packaged branch itself still needs an on-device installation pass before merge.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/SierraSoftworks/tailscale-unifi#contributing) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/SierraSoftworks/tailscale-unifi/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests (excluding integration tests) for your changes?
- [x] Have you successfully run your changes locally?

---

- [x] AI was used to assist with this PR. Codex helped implement the renewal flow, tests, refactoring and PR draft. I reviewed the resulting diff, ran the complete test suite and ShellCheck, and verified the underlying renewal procedure against the live UDM Pro Max failure.